### PR TITLE
feat: Adds regex-based filtering capabilities to obfuscation

### DIFF
--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -37,6 +37,8 @@ var _dynamic_id_seed : bool
 var _strip_comments : bool
 var _strip_empty_lines : bool
 var _feature_filters : bool
+var _regex_filter_enabled : bool
+var _regex_filter : String
 var _source_map_path : String
 var _source_map_max_files : int
 var _source_map_compress : bool
@@ -70,6 +72,8 @@ func _export_begin(features : PackedStringArray, is_debug : bool, path : String,
 	_id_seed = cfg.get_value("id", "seed", 0) if !_dynamic_id_seed else int(Time.get_unix_time_from_system())
 	_strip_comments = cfg.get_value("post_process", "strip_comments", false)
 	_strip_empty_lines = cfg.get_value("post_process", "strip_empty_lines", false)
+	_regex_filter_enabled = cfg.get_value("post_process", "regex_filter_enabled", false)
+	_regex_filter = cfg.get_value("post_process", "regex_filter", "")
 	_feature_filters = cfg.get_value("post_process", "feature_filters", false)
 	_source_map_path = cfg.get_value("source_mapping", "filepath", "")
 	_source_map_max_files = cfg.get_value("source_mapping", "max_files", 1)
@@ -939,6 +943,15 @@ func _obfuscate_script(path : String) -> String:
 		for i in range(line_mapper.get_line_count() - 1, -1, -1):
 			var line : ScriptData.Line = line_mapper.get_line(i)
 			if line.text.replace(" ", "").replace("\n", "").replace("\t", "").length() == 0:
+				line_mapper.remove_line(i)
+				continue
+	
+	if _regex_filter_enabled:
+		var regex = RegEx.new()
+		regex.compile(_regex_filter)
+		for i in range(line_mapper.get_line_count() - 1, -1, -1):
+			var line : ScriptData.Line = line_mapper.get_line(i)
+			if regex.search(line.source_text):
 				line_mapper.remove_line(i)
 				continue
 	

--- a/addons/gdmaim/ui/dock.gd
+++ b/addons/gdmaim/ui/dock.gd
@@ -21,6 +21,8 @@ var _write_queued : bool = false
 @onready var dynamic_seed : CheckBox = $ScrollContainer/VBoxContainer/DynamicSeed/CheckBox
 @onready var strip_comments : CheckBox = $ScrollContainer/VBoxContainer/StripComments/CheckBox
 @onready var strip_empty_lines : CheckBox = $ScrollContainer/VBoxContainer/StripEmptyLines/CheckBox
+@onready var regex_filter_enabled : CheckBox = $ScrollContainer/VBoxContainer/RegExFilters/CheckBox
+@onready var regex_filter : LineEdit = $ScrollContainer/VBoxContainer/RegExFilter
 @onready var feature_filters : CheckBox = $ScrollContainer/VBoxContainer/FeatureFilters/CheckBox
 @onready var source_map_path : LineEdit = $ScrollContainer/VBoxContainer/SourceMapPath/LineEdit
 @onready var source_map_max_files : SpinBox = $ScrollContainer/VBoxContainer/SourceMapMaxFiles/SpinBox
@@ -59,6 +61,8 @@ func _read_cfg() -> void:
 	strip_comments.button_pressed = cfg.get_value("post_process", "strip_comments", false)
 	strip_empty_lines.button_pressed = cfg.get_value("post_process", "strip_empty_lines", false)
 	feature_filters.button_pressed = cfg.get_value("post_process", "feature_filters", false)
+	regex_filter_enabled.button_pressed = cfg.get_value("post_process", "regex_filter_enabled", false)
+	regex_filter.text = cfg.get_value("post_process", "regex_filter", "")
 	source_map_path.text = cfg.get_value("source_mapping", "filepath", "")
 	source_map_max_files.value = cfg.get_value("source_mapping", "max_files", 1)
 	source_map_max_compress.button_pressed = cfg.get_value("source_mapping", "compress", false)
@@ -90,6 +94,8 @@ func _write_cfg(force : bool = false) -> void:
 	cfg.set_value("post_process", "strip_comments", strip_comments.button_pressed)
 	cfg.set_value("post_process", "strip_empty_lines", strip_empty_lines.button_pressed)
 	cfg.set_value("post_process", "feature_filters", feature_filters.button_pressed)
+	cfg.set_value("post_process", "regex_filter_enabled", regex_filter_enabled.button_pressed)
+	cfg.set_value("post_process", "regex_filter", regex_filter.text)
 	cfg.set_value("source_mapping", "filepath", source_map_path.text)
 	cfg.set_value("source_mapping", "max_files", int(source_map_max_files.value))
 	cfg.set_value("source_mapping", "compress", source_map_max_compress.button_pressed)

--- a/addons/gdmaim/ui/dock.tscn
+++ b/addons/gdmaim/ui/dock.tscn
@@ -270,6 +270,39 @@ theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_bv73c")
 theme_override_styles/focus = SubResource("StyleBoxFlat_bv73c")
 text = "On"
 
+[node name="RegExFilters" type="Label" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+tooltip_text = "Strip Lines Matching RegEx
+If true, any lines matching the regular expression will be removed from the obfuscated code.
+"
+mouse_filter = 1
+text = "Strip Lines Matching RegEx"
+vertical_alignment = 1
+
+[node name="CheckBox" type="CheckBox" parent="ScrollContainer/VBoxContainer/RegExFilters"]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -42.0
+offset_top = -9.5
+offset_bottom = 9.5
+grow_horizontal = 0
+grow_vertical = 2
+theme_override_styles/normal = SubResource("StyleBoxFlat_bv73c")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_bv73c")
+theme_override_styles/disabled = SubResource("StyleBoxFlat_bv73c")
+theme_override_styles/hover = SubResource("StyleBoxFlat_bv73c")
+theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_bv73c")
+theme_override_styles/focus = SubResource("StyleBoxFlat_bv73c")
+text = "On"
+
+[node name="RegExFilter" type="LineEdit" parent="ScrollContainer/VBoxContainer"]
+layout_mode = 2
+placeholder_text = "Enter Regular Expression"
+
 [node name="FeatureFilters" type="Label" parent="ScrollContainer/VBoxContainer"]
 layout_mode = 2
 tooltip_text = "Process Feature Filters
@@ -627,6 +660,8 @@ text = "On"
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/ObfuscateSignals/CheckBox" to="." method="_on_check_box_toggled"]
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/StripComments/CheckBox" to="." method="_on_check_box_toggled"]
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/StripEmptyLines/CheckBox" to="." method="_on_check_box_toggled"]
+[connection signal="toggled" from="ScrollContainer/VBoxContainer/RegExFilters/CheckBox" to="." method="_on_check_box_toggled"]
+[connection signal="text_changed" from="ScrollContainer/VBoxContainer/RegExFilter" to="." method="_on_line_edit_text_changed"]
 [connection signal="toggled" from="ScrollContainer/VBoxContainer/FeatureFilters/CheckBox" to="." method="_on_check_box_toggled"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/IDPrefix/LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="text_changed" from="ScrollContainer/VBoxContainer/IDCharacterList/LineEdit" to="." method="_on_line_edit_text_changed"]


### PR DESCRIPTION
This change adds the ability to filter lines based on a regular expression during export:

![image](https://github.com/cherriesandmochi/gdmaim/assets/36222624/d3c784aa-29df-4a11-9697-783dd83cfd13)

During development, some of my scripts allow for debug output that I'm using for tracing the more complex interactions and logic flow:

```gdscript
@export var DEBUG: bool = false
```
Methods then have print statements that give away the original method name after obfuscation:
```gdscript
func _cl_opened(actor_path, context_id, nonce):
	if DEBUG: print_debug("%s::_cl_opened(%s, %s, %s)" % [self, actor_path, context_id, nonce])
```

This is also useful for stripping [assert()](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html#assert-keyword)s that might give away details.

By specifying `var DEBUG: bool|if DEBUG:|assert\(` as regex, those lines will be stripped from the maimed code:

![image](https://github.com/cherriesandmochi/gdmaim/assets/36222624/b0bc7b48-ff05-41d4-8fef-60bfc2cf2b52)

