### PR TITLE
Block shuffling fixes and checks

### DIFF
--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -190,8 +190,17 @@ func _func_feature_filter(token : Token, line : Tokenizer.Line, feature : String
 func _shuffle_toplevel() -> void:
 	var lines : Array[Tokenizer.Line] = tokenizer.get_output_lines()
 	var top_block : Array
-	var on_ready : Array
-	var blocks : Array[Array] = [[]]
+	var on_ready : Array[Array] = []
+	var blocks : Array[Array] = []
+	var current_block : Array
+	var current_is_onready : bool
+	
+	var add_block = func(block : Array, is_onready : bool):
+		if block.is_empty(): return
+		if is_onready:
+			on_ready.append(block)
+		else:
+			blocks.append(block)
 	
 	for i in lines.size():
 		var line : Tokenizer.Line = lines[i]
@@ -202,12 +211,17 @@ func _shuffle_toplevel() -> void:
 			top_block.append(line)
 			continue
 		if starter_token and starter_token.get_value() == "@onready":
-			on_ready.append(line)
-			continue
-		if line.get_identation() == 0 and starter_token and starter_token.is_keyword() and (!prev_starter_token or (!prev_starter_token.has_value("@rpc") and !(prev_starter_token.get_value().begins_with("@export") and !prev_line.has_token_value("var")))):
-			blocks.append([])
+			add_block.call(current_block, current_is_onready)
+			current_block = []
+			current_is_onready = true
+		elif line.get_identation() == 0 and starter_token and starter_token.is_keyword() and (!prev_starter_token or (!prev_starter_token.has_value("@rpc") and !(prev_starter_token.get_value().begins_with("@export") and !prev_line.has_token_value("var")))):
+			add_block.call(current_block, current_is_onready)
+			current_block = []
+			current_is_onready = false
 		
-		blocks.back().append(line)
+		current_block.append(line)
+	
+	add_block.call(current_block, current_is_onready)
 	
 	var w_blocks : Dictionary
 	var random := RandomNumberGenerator.new()
@@ -226,9 +240,10 @@ func _shuffle_toplevel() -> void:
 		var idx : int = 0
 		var max_spacing : int = mini(blocks.size() / on_ready.size() * 2, blocks.size() + 1)
 		random.seed = hash(path) + path.length() + _symbol_table._seed
-		for line in on_ready:
-			idx += maxi(1, random.randi() % max_spacing)
-			blocks.insert(mini(idx, blocks.size()), [line])
+		for block in on_ready:
+			if max_spacing:
+				idx += maxi(1, random.randi() % max_spacing)
+			blocks.insert(mini(idx, blocks.size()), block)
 	
 	lines.clear()
 	for block in [top_block] + blocks:


### PR DESCRIPTION
Multi-line onready statements would get chopped up during shuffling and causing invalid syntax code.

![Godot_v4 3-stable_win64_2025-01-09_11-47-37](https://github.com/user-attachments/assets/ca88f377-ca7c-423d-a2fc-8a394825ff5b)
![Godot_v4 3-stable_win64_2025-01-09_11-53-15](https://github.com/user-attachments/assets/cfab7005-a79c-454c-b6e2-3d33254cdaef)

I've done a slight rework to make it support multi-line onready. Ideally an array could just be one line, but this should prevent any future issues.

![Godot_v4 3-stable_win64_2025-01-09_12-28-55](https://github.com/user-attachments/assets/7ca4d91f-c7c9-4bbc-ad06-ec15f3eccd15)
![Godot_v4 3-stable_win64_2025-01-09_12-26-31](https://github.com/user-attachments/assets/8f89a464-b3c6-4691-9541-7bbfda0148e3)

Additionally I've made it stopped printing division errors if a gd file is mostly made of onready statements.