### PR TITLE
General improvements and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ To configure this plugin, open the GDMaim dock on the bottom left, right next to
 
 `Shuffle Top-Level Declarations`: Shuffles the line positions of top-level declarations, such as variables, functions and classes.
 
+`Inline Statements`: If enabled, aggressively compresses multiple lines of code into as little lines as possible.
+
 `Inline Constants`: If enabled, accesses to constants will be replaced with hardcoded values. Declarations of constants get removed.
 
 `Inline enums`: If enabled, accesses to enum keys will be replaced with hardcoded values. Declarations of enums get removed.

--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -134,7 +134,8 @@ func _export_begin(features : PackedStringArray, is_debug : bool, path : String,
 	var class_cache := ConfigFile.new()
 	var class_cache_src : PackedByteArray = FileAccess.get_file_as_bytes(GODOT_CLASS_CACHE_PATH)
 	class_cache.parse(class_cache_src.get_string_from_utf8())
-	var classes : Array[Dictionary] = class_cache.get_value("", "list")
+	var classes : Array[Dictionary] = []
+	classes.assign(class_cache.get_value("", "list"))
 	for class_data : Dictionary in classes:
 		if _class_symbols.has(class_data.class):
 			class_data.class = StringName(_class_symbols[class_data.class].get_name())

--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -342,7 +342,7 @@ func _obfuscate_script(path : String) -> String:
 				if token.get_value() == "_enter_tree":
 					found_func = true
 					break
-				if found_func and token.type == Token.Type.IDENTATION:
+				if found_func and token.type == Token.Type.INDENTATION:
 					line.insert_token(i + 1, Token.new(Token.Type.LITERAL, injection_code, -1, -1))
 					did_inject = true
 					break

--- a/addons/gdmaim/obfuscator/script/parser/ast.gd
+++ b/addons/gdmaim/obfuscator/script/parser/ast.gd
@@ -13,10 +13,10 @@ class ASTNode:
 	func _to_string() -> String: return "pass" if parent else "root"
 	func get_parent() -> ASTNode: return parent.get_ref() as ASTNode if parent else null
 	func get_children() -> Array[ASTNode]: return children
-	func print_tree(identation : int = 0, identation_str : String = ">   ") -> String:
-		var str : String = "\n" + (identation_str.repeat(identation) if identation > 0 else "") + str(self)
+	func print_tree(indentation : int = 0, indentation_str : String = ">   ") -> String:
+		var str : String = "\n" + (indentation_str.repeat(indentation) if indentation > 0 else "") + str(self)
 		for child in get_children():
-			str += child.print_tree(identation + 1)
+			str += child.print_tree(indentation + 1)
 		return str
 
 

--- a/addons/gdmaim/obfuscator/script/parser/ast.gd
+++ b/addons/gdmaim/obfuscator/script/parser/ast.gd
@@ -134,6 +134,7 @@ class ExportVar extends Var:
 class ExportNodePathVar extends ExportVar:
 	var types : Array[StringSymbol]
 	func _to_string() -> String: return "@export_node_path var " + str(symbol)
+	func get_children() -> Array: return types + super()
 
 
 class Parameter extends Var:
@@ -147,7 +148,7 @@ class Symbol extends ASTNode:
 
 class StringSymbol extends ASTNode:
 	var path : SymbolTable.SymbolPath
-	func _to_string() -> String: return "quoted symbol " + str(path)
+	func _to_string() -> String: return 'symbol "' + str(path) + '"'
 
 
 class Call extends Symbol:

--- a/addons/gdmaim/obfuscator/script/parser/ast.gd
+++ b/addons/gdmaim/obfuscator/script/parser/ast.gd
@@ -129,6 +129,11 @@ class ExportVar extends Var:
 	func _to_string() -> String: return "@export var " + str(symbol)
 
 
+class ExportNodePathVar extends ExportVar:
+	var types : Array[StringSymbol]
+	func _to_string() -> String: return "@export_node_path var " + str(symbol)
+
+
 class Parameter extends Var:
 	func _to_string() -> String: return "param " + str(symbol)
 
@@ -136,6 +141,11 @@ class Parameter extends Var:
 class Symbol extends ASTNode:
 	var path : SymbolTable.SymbolPath
 	func _to_string() -> String: return "symbol " + str(path)
+
+
+class StringSymbol extends ASTNode:
+	var path : SymbolTable.SymbolPath
+	func _to_string() -> String: return "quoted symbol " + str(path)
 
 
 class Call extends Symbol:

--- a/addons/gdmaim/obfuscator/script/parser/ast.gd
+++ b/addons/gdmaim/obfuscator/script/parser/ast.gd
@@ -117,8 +117,10 @@ class EnumDef extends SymbolDeclaration:
 
 
 class Var extends SymbolDeclaration:
-	var default : String
+	var default : Sequence
+	var getset : Sequence
 	func _to_string() -> String: return "var " + str(symbol)
+	func get_children() -> Array[ASTNode]: return (default.statements if default else ([] as Array[ASTNode])) + (getset.statements if getset else ([] as Array[ASTNode]))
 
 
 class Const extends Var:

--- a/addons/gdmaim/obfuscator/script/parser/parser.gd
+++ b/addons/gdmaim/obfuscator/script/parser/parser.gd
@@ -65,7 +65,7 @@ func _parse_block_with_callback(parent : AST.ASTNode, indentation : int, token_p
 
 
 func _parse_block(parent : AST.ASTNode, indentation : int) -> AST.Sequence:
-	return _parse_block_with_callback(parent, indentation, func(ast : AST.Sequence, line : Tokenizer.Line, token : Token, identation : int):
+	return _parse_block_with_callback(parent, indentation, func(ast : AST.Sequence, line : Tokenizer.Line, token : Token, indentation : int):
 		if parent is AST.Match and token.is_punctuator(":") and line.get_indentation() == indentation + 1:
 			ast.statements.append(_parse_block(ast, indentation + 1))
 		else:
@@ -796,7 +796,7 @@ func _parse_var_default(parent : AST.ASTNode) -> AST.Sequence:
 		
 		_bracket_lock = 0
 		
-		var ast: AST.Sequence = _parse_block_with_callback(parent, indentation, func(ast : AST.Sequence, line : Tokenizer.Line, token : Token, identation : int):
+		var ast: AST.Sequence = _parse_block_with_callback(parent, indentation, func(ast : AST.Sequence, line : Tokenizer.Line, token : Token, indentation : int):
 			match token.type:
 				Token.Type.KEYWORD:
 					_tokenizer.get_next()
@@ -835,7 +835,7 @@ func _parse_var_getset(parent : AST.ASTNode) -> AST.Sequence:
 		
 		_bracket_lock = 0
 		
-		var ast: AST.Sequence = _parse_block_with_callback(parent, indentation, func(ast : AST.Sequence, line : Tokenizer.Line, token : Token, identation : int):
+		var ast: AST.Sequence = _parse_block_with_callback(parent, indentation, func(ast : AST.Sequence, line : Tokenizer.Line, token : Token, indentation : int):
 			if token.is_symbol("get") or token.is_symbol("set"):
 				var function : AST.Func = _parse_func(ast)
 				if function:

--- a/addons/gdmaim/obfuscator/script/parser/parser.gd
+++ b/addons/gdmaim/obfuscator/script/parser/parser.gd
@@ -74,10 +74,6 @@ func _parse_block(parent : AST.ASTNode, indentation : int) -> AST.Sequence:
 				ast.statements.append(statement)
 		return true
 		)
-	
-	ast.token_to = _tokenizer.peek(0)
-	
-	return ast
 
 
 func _parse_and_process_indentation() -> bool:

--- a/addons/gdmaim/obfuscator/script/parser/parser.gd
+++ b/addons/gdmaim/obfuscator/script/parser/parser.gd
@@ -792,6 +792,12 @@ func _parse_var_default(parent : AST.ASTNode) -> AST.Sequence:
 		
 		var ast: AST.Sequence = _parse_block_with_callback(parent, indentation, func(ast : AST.Sequence, line : Tokenizer.Line, token : Token, identation : int):
 			match token.type:
+				Token.Type.KEYWORD:
+					_tokenizer.get_next()
+					if token.is_keyword('func'):
+						var function : AST.Func = _parse_func(ast)
+						if function:
+							ast.statements.append(function)
 				Token.Type.SYMBOL:
 					var symbol : AST.ASTNode = _parse_symbol(ast)
 					if symbol:

--- a/addons/gdmaim/obfuscator/script/parser/parser.gd
+++ b/addons/gdmaim/obfuscator/script/parser/parser.gd
@@ -533,7 +533,7 @@ func _parse_enum_key(parent : AST.ASTNode) -> AST.EnumDef.KeyDef:
 	
 	if parent is AST.SymbolDeclaration and parent.symbol:
 		parent.symbol.add_child(key.symbol)
-	else:
+	elif _class_symbol:
 		_class_symbol.add_child(key.symbol)
 	
 	token = _tokenizer.peek()

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -529,6 +529,8 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 					scope_indents.pop_back()
 					scope_start_idx.pop_back()
 					scope_can_inline.pop_back()
+					if scope_brackets.back() == '{':
+						temporary_statement_scope_count -= 1
 					
 					prev_line_lambda = false
 					# Only allow merging into this line if the next symbol is a punctuator and we're inside of brackets right now

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -597,10 +597,12 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 				var inner_scope_has_if : bool = false
 				for inner_scope_line_idx in range(current_scope_start_idx, mini(i, lines.size())):
 					var inner_scope_line : Tokenizer.Line = lines[inner_scope_line_idx]
+					var inner_scope_line_statement_reset : bool = true
 					for inner_scope_if_lookahead in inner_scope_line.tokens:
 						if inner_scope_if_lookahead.is_of_type(Token.Type.WHITESPACE | Token.Type.INDENTATION): continue
-						elif inner_scope_if_lookahead.is_keyword("if"): inner_scope_has_if = true; break
-						else: break
+						elif inner_scope_if_lookahead.is_keyword("if") and inner_scope_line_statement_reset: inner_scope_has_if = true; break
+						elif inner_scope_if_lookahead.is_punctuator(";"): inner_scope_line_statement_reset = true
+						else: inner_scope_line_statement_reset = false
 				
 				# Also optimise by checking which IF this ELSE belongs to
 				var if_indent : String = "" if scope_indents.size() < 1 else scope_indents[internal_indent_index-1]

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -507,7 +507,7 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 			line.remove_token(0)
 		
 		# Some keywords (like export in certain scenarios or @export_group) MUST end in a new line
-		var standalone_annotations := (first_token.is_keyword() or first_token.is_annotation()) and first_token.get_value() in ["extends", "@export_group", "@export_subgroup"]
+		var standalone_annotations := (first_token.is_keyword() or first_token.is_annotation()) and first_token.get_value() in ["extends", "@export_group", "@export_subgroup", "@export_category"]
 		# Search for unfinished statements, such as @annotations that dont follow the statement they're annotating in the same line or keywords like `extends` and `class_name`
 		var top_level_class_annotation := (first_token.is_keyword() or first_token.is_annotation()) and first_token.get_value() in ["extends", "class_name", "@tool", "@icon"]
 		var is_line_extending_prev_line = top_level_class_annotation or prev_line_decorator

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -516,6 +516,7 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 		var line_has_control := false
 		var line_has_inline_control := false
 		var line_has_lambda_func := false
+		var line_has_lambda_func_open := false
 		var line_has_possible_static_func := false
 		# Get set tracking
 		var line_getset_conditions := 0  # 0: nothing, 1: 'var' keyword
@@ -534,6 +535,7 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 				scope_brackets_count -= 1
 			
 			elif token.type == Token.Type.PUNCTUATOR and token.get_value() == ":":
+				if line_has_lambda_func: line_has_lambda_func_open = true
 				if scope_brackets_count > 0: continue
 				if line_has_control: line_has_inline_control = true
 				if line_getset_function_conditions == 2: line_has_getset_function = true
@@ -556,6 +558,10 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 				if line_still_indenting: line_getset_function_conditions = 2
 			elif token.type == Token.Type.SYMBOL and token.get_value() == 'set':
 				if line_still_indenting: line_getset_function_conditions = 1
+			
+			if line_has_lambda_func_open and !token.is_of_type(Token.Type.WHITESPACE | Token.Type.LINE_BREAK | Token.Type.COMMENT):
+				line_has_lambda_func_open = false
+				line_has_lambda_func = false
 			
 			if line_still_indenting and (!token.is_whitespace() and !token.is_indentation()):
 				line_still_indenting = false
@@ -659,6 +665,6 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 		else:
 			empty_line_counter = 0
 		
-		prev_line_lambda = line_has_lambda_func
+		prev_line_lambda = line_has_lambda_func_open
 	
 	return i

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -373,10 +373,16 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 			while not active_break_line.tokens.is_empty() and !active_break_line.tokens[active_break_line.tokens.size() - 1].is_statement_break():
 				active_break_line.remove_token(active_break_line.tokens.size() - 1)
 			
-			# Convert the \ into a space
+			var before_newline_token : Token = active_break_line.tokens[active_break_line.tokens.size() - 2] if active_break_line.tokens.size() > 1 else null
 			var slash_token : Token = active_break_line.tokens.back()
-			slash_token.type = Token.Type.WHITESPACE
-			slash_token.set_value(' ')
+			
+			# Convert the \ into a space
+			# Optimise: dont convert to space if the space is already there
+			if before_newline_token and before_newline_token.is_whitespace():
+				active_break_line.tokens.remove_at(active_break_line.tokens.size() - 1)
+			else:
+				slash_token.type = Token.Type.WHITESPACE
+				slash_token.set_value(' ')
 
 			# Remove leading indentation if exists
 			if first_token.is_of_type(Token.Type.WHITESPACE | Token.Type.INDENTATION):

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -513,6 +513,14 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 					var internal_indent_index = scope_indents.size()-1
 					var current_scope_start_idx := scope_start_idx[internal_indent_index]
 					var head_line : Tokenizer.Line = lines[current_scope_start_idx-1]
+					
+					# Don't merge scope if it contains warning ignore and would merge into one line with func def
+					if i - current_scope_start_idx - empty_line_counter == 1:
+						for token in lines[i-1].tokens:
+							if token.type == Token.Type.ANNOTATION and token.has_value("@warning_ignore"):
+								scope_can_inline[scope_can_inline.size()-1] = false
+								break
+					
 					# Make sure if we will merge, it will not be into a comment!
 					# Also check if we're allowed to inline this scope, not all scopes can
 					if i - current_scope_start_idx - empty_line_counter == 1 and (head_line.tokens.size() > 2 and not head_line.tokens[head_line.tokens.size()-2].is_comment()) and scope_can_inline[internal_indent_index]:

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -739,5 +739,15 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 		
 		prev_line_func = line_has_func
 		prev_line_lambda = line_has_lambda_func
+		
+		# End recursive call if this line contains a comman when this call assumes to be out of brackets
+		# Similarly end if we're in negative brackets
+		if scope_brackets_count < 0: return i
+		var _temp_scope_bracket_count : int = 0
+		for punc_i in range(0, line.tokens.size()):
+			var token : Token = line.tokens[punc_i]
+			if token.is_punctuator('('): _temp_scope_bracket_count += 1
+			elif token.is_punctuator(')'): _temp_scope_bracket_count -= 1
+			elif token.is_punctuator(',') and (scope_brackets_count + maxi(_temp_scope_bracket_count, 0)) == 0: return i
 	
 	return i

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -102,8 +102,8 @@ func _string_obfuscation(token : Token) -> void:
 	if !token.is_string_literal():
 		return
 	
-	var str : String = token.get_value()
-	token.set_value(str[0] + _symbol_table.obfuscate_string_global(str.substr(1, str.length() - 2)) + str[-1])
+	var str : String = token.get_value(false)
+	token.set_value(_symbol_table.obfuscate_string_global(str))
 
 
 func _string_param_obfuscation(token : Token, next_token : Token) -> void:
@@ -131,8 +131,8 @@ func _string_param_obfuscation(token : Token, next_token : Token) -> void:
 				maybe_str_param = true
 			continue
 		elif maybe_str_param and token.is_string_literal() and symbol.is_string_param(param):
-			var str : String = token.get_value()
-			token.set_value(str[0] + _symbol_table.obfuscate_string_global(str.substr(1, str.length() - 2)) + str[-1])
+			var str : String = token.get_value(false)
+			token.set_value(_symbol_table.obfuscate_string_global(str))
 		maybe_str_param = false
 
 

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -511,6 +511,11 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 		if scope_indent != "" and (not is_indented or current_indent.length() < scope_indent.length()):
 			return i
 		
+		# Don't merge scope if it contains warning ignore and would merge into one line with func def
+		for token in line.tokens:
+			if token.type == Token.Type.ANNOTATION and token.has_value("@warning_ignore") and scope_start_idx.back() + 1 < i:
+				scope_can_inline[scope_can_inline.size()-1] = false
+		
 		# Clear leading indent
 		if process_curent_line and is_indented and not line_empty:
 			line.remove_token(0)
@@ -715,6 +720,7 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 		else:
 			empty_line_counter = 0
 		
+		prev_line_func = line_has_func
 		prev_line_lambda = line_has_lambda_func
 	
 	return i

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -431,8 +431,6 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 				# It needs to be non-inline, so we check if we scoped in here
 				if prev_line_lambda:
 					i = _combine_statement_lines(i-1, current_indent) - 1
-					print('\n\n\n\n\n\n\n')
-					print(tokenizer.generate_source_code())
 					
 					var internal_indent_index = scope_indents.size()-1
 					var current_scope_start_idx := scope_start_idx[internal_indent_index]

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -590,7 +590,7 @@ func _combine_statement_lines(starting_line: int = 1, scope_indent: String = "")
 				# Check if it has an else keyword
 				for else_lookahead in else_lookahead_line.tokens:
 					if else_lookahead.is_of_type(Token.Type.WHITESPACE | Token.Type.INDENTATION): else_lookahead_indent += else_lookahead.get_value(false)
-					elif else_lookahead.is_keyword("else"): scope_change_contains_else = true; break
+					elif else_lookahead.is_keyword("else") or else_lookahead.is_keyword("elif"): scope_change_contains_else = true; break
 					else: break
 				
 				# Check if the scope we just exited contains any if statements

--- a/addons/gdmaim/obfuscator/script/tokenizer/token.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/token.gd
@@ -16,6 +16,7 @@ enum Type {
 	WHITESPACE = 2**10,
 	INDENTATION = 2**11,
 	LINE_BREAK = 2**12,
+	STATEMENT_BREAK = 2**13,
 }
 
 const StringRef := preload("../../string_ref.gd")
@@ -48,7 +49,7 @@ func set_value(new_val : String) -> void:
 
 func get_value(decorated : bool = true) -> String:
 	if !decorated:
-	return str(_value)
+		return str(_value)
 	return decorator + str(_value) + decorator
 
 
@@ -115,6 +116,10 @@ func is_indentation(value : String = "") -> bool:
 
 func is_line_break(value : String = "") -> bool:
 	return type == Type.LINE_BREAK and (!value or get_value() == value)
+
+
+func is_statement_break(value : String = "") -> bool:
+	return type == Type.STATEMENT_BREAK and (!value or get_value() == value)
 
 
 func is_of_type(type_bitflags : int) -> bool:

--- a/addons/gdmaim/obfuscator/script/tokenizer/token.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/token.gd
@@ -24,15 +24,17 @@ const SymbolTable := preload("../../symbol_table.gd")
 var type : Type
 var idx : int
 var line : int
+var decorator : String
 var symbol : SymbolTable.Symbol
 
 var _value := StringRef.new()
 
 
-func _init(type : Type, value : String, idx : int, line : int) -> void:
+func _init(type : Type, value : String, idx : int, line : int, decorator : String = "") -> void:
 	self.type = type
 	self.idx = idx
 	self.line = line
+	self.decorator = decorator
 	_value.set_value(value)
 
 
@@ -41,11 +43,13 @@ func _to_string() -> String:
 
 
 func set_value(new_val : String) -> void:
-	_value.set_value(new_val)
+	_value.set_value(new_val.substr(len(decorator), len(new_val)-len(decorator)) if decorator else new_val)
 
 
-func get_value() -> String:
+func get_value(decorated : bool = true) -> String:
+	if !decorated:
 	return str(_value)
+	return decorator + str(_value) + decorator
 
 
 func link_value(root : StringRef) -> void:

--- a/addons/gdmaim/obfuscator/script/tokenizer/token.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/token.gd
@@ -3,18 +3,19 @@ extends RefCounted
 
 enum Type {
 	NONE = 0,
-	SYMBOL = 2^0,
-	KEYWORD = 2^1,
-	LITERAL = 2^2,
-	NUMBER_LITERAL = 2^3,
-	STRING_LITERAL = 2^4,
-	NODE_PATH = 2^5,
-	PUNCTUATOR = 2^6,
-	OPERATOR = 2^7,
-	COMMENT = 2^8,
-	WHITESPACE = 2^9,
-	IDENTATION = 2^10,
-	LINE_BREAK = 2^11,
+	SYMBOL = 2**0,
+	KEYWORD = 2**1,
+	LITERAL = 2**2,
+	NUMBER_LITERAL = 2**3,
+	STRING_LITERAL = 2**4,
+	NODE_PATH = 2**5,
+	ANNOTATION = 2**6,
+	PUNCTUATOR = 2**7,
+	OPERATOR = 2**8,
+	COMMENT = 2**9,
+	WHITESPACE = 2**10,
+	INDENTATION = 2**11,
+	LINE_BREAK = 2**12,
 }
 
 const StringRef := preload("../../string_ref.gd")
@@ -84,6 +85,10 @@ func is_node_path(value : String = "") -> bool:
 	return type == Type.NODE_PATH and (!value or get_value() == value)
 
 
+func is_annotation(value : String = "") -> bool:
+	return type == Type.ANNOTATION and (!value or get_value() == value)
+
+
 func is_punctuator(value : String = "") -> bool:
 	return type == Type.PUNCTUATOR and (!value or get_value() == value)
 
@@ -100,9 +105,13 @@ func is_whitespace(value : String = "") -> bool:
 	return type == Type.WHITESPACE and (!value or get_value() == value)
 
 
-func is_identation(value : String = "") -> bool:
-	return type == Type.IDENTATION and (!value or get_value() == value)
+func is_indentation(value : String = "") -> bool:
+	return type == Type.INDENTATION and (!value or get_value() == value)
 
 
 func is_line_break(value : String = "") -> bool:
 	return type == Type.LINE_BREAK and (!value or get_value() == value)
+
+
+func is_of_type(type_bitflags : int) -> bool:
+	return (type & type_bitflags) || type == type_bitflags

--- a/addons/gdmaim/obfuscator/script/tokenizer/token.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/token.gd
@@ -40,7 +40,7 @@ func _init(type : Type, value : String, idx : int, line : int, decorator : Strin
 
 
 func _to_string() -> String:
-	return str(_value)
+	return str(get_value())
 
 
 func set_value(new_val : String) -> void:

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -148,7 +148,7 @@ func _read_next_token() -> bool:
 		_add_statement_break()
 	elif _is_whitespace(char):
 		if _stream.get_column_pos() == 0:
-			# Identation
+			# Indentation
 			_read_indentation()
 		else:
 			# Whitespace
@@ -390,7 +390,7 @@ func _add_statement_break() -> void:
 class Line:
 	var tokens : Array[Token]
 	var hints : Dictionary
-	var identation : int
+	var indentation : int
 	
 	func _init(tokens : Array[Token] = []) -> void:
 		self.tokens = tokens
@@ -413,10 +413,10 @@ class Line:
 	func erase_token(token : Token) -> void:
 		tokens.erase(token)
 	
-	func clear_tokens(keep_identation : bool = true) -> void:
+	func clear_tokens(keep_indentation : bool = true) -> void:
 		for i in range(tokens.size() - 1, -1, -1):
 			var token : Token = tokens[i]
-			if !token.is_line_break() and (!keep_identation or !token.is_indentation()):
+			if !token.is_line_break() and (!keep_indentation or !token.is_indentation()):
 				tokens.remove_at(i)
 	
 	func add_hint(hint : String, args : String) -> void:

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -132,12 +132,7 @@ func _read_next_token() -> bool:
 	if _stream.is_eof():
 		return false
 	
-	if _stream.peek(1) == "\\" and _stream.peek(2) == "\n":
-		# Multi-line statement
-		_stream.get_next()
-		_stream.get_next()
-		return true
-	elif _stream.peek() == "\n":
+	if _stream.peek() == "\n":
 		# Line break
 		_stream.get_next()
 		_add_line_break()
@@ -147,7 +142,11 @@ func _read_next_token() -> bool:
 		return true
 	
 	var char : String = _stream.peek()
-	if _is_whitespace(char):
+	if char == '\\':
+		# Statement break
+		_stream.get_next()
+		_add_statement_break()
+	elif _is_whitespace(char):
 		if _stream.get_column_pos() == 0:
 			# Identation
 			_read_indentation()
@@ -382,6 +381,10 @@ func _add_indentation(indentation : int) -> void:
 
 func _add_line_break() -> void:
 	_add_token(Token.Type.LINE_BREAK, "\n")
+
+
+func _add_statement_break() -> void:
+	_add_token(Token.Type.STATEMENT_BREAK, "\\")
 
 
 class Line:

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -6,11 +6,11 @@ const _Settings := preload("../../../settings.gd")
 const Token := preload("token.gd")
 const Stream := preload("stream.gd")
 
-const KEYWORDS : Array[String] = ["extends", "class_name", "@tool", "@onready", "setget", "const", "signal", "enum", "static", "var", "func","@rpc", "class", "pass", "if", "else", "elif", "while", "for", "in", "match", "continue", "break", "return", "assert", "yield", "await", "preload", "load", "as", "and", "or", "not"]
+const KEYWORDS : Array[String] = ["extends", "class_name", "setget", "const", "signal", "enum", "static", "var", "func", "class", "pass", "if", "else", "elif", "while", "for", "in", "match", "continue", "break", "return", "assert", "yield", "await", "preload", "load", "as", "and", "or", "not"]
 const LITERALS : Array[String] = ["true", "false", "null", "self", "PI", "TAU", "NAN", "INF"]
 const OPERATORS : String = "+-*^/%=<>!&|"
 const PUNCTUATORS : String = "()[]{},;:."
-const IDENTIFIER_CHARACTERS : String = "1234567890_@"
+const IDENTIFIER_CHARACTERS : String = "1234567890_"
 
 var line_count : int
 
@@ -45,7 +45,7 @@ func get_next() -> Token:
 	return _tokens[_idx] if _idx < _tokens.size() else null
 
 
-func get_next_filtered(type_filter : int = Token.Type.WHITESPACE + Token.Type.COMMENT + Token.Type.IDENTATION + Token.Type.LINE_BREAK) -> Token:
+func get_next_filtered(type_filter : int = Token.Type.WHITESPACE | Token.Type.COMMENT | Token.Type.INDENTATION | Token.Type.LINE_BREAK) -> Token:
 	var token : Token = peek_next_filtered(type_filter)
 	if token:
 		seek_token(token)
@@ -55,7 +55,7 @@ func get_next_filtered(type_filter : int = Token.Type.WHITESPACE + Token.Type.CO
 	return token
 
 
-func peek_next_filtered(type_filter : int = Token.Type.WHITESPACE + Token.Type.COMMENT + Token.Type.IDENTATION + Token.Type.LINE_BREAK) -> Token:
+func peek_next_filtered(type_filter : int = Token.Type.WHITESPACE | Token.Type.COMMENT | Token.Type.INDENTATION | Token.Type.LINE_BREAK) -> Token:
 	for i in range(_idx + 1, _tokens.size()):
 		var token : Token = _tokens[i]
 		if !(token.type & type_filter):
@@ -148,7 +148,7 @@ func _read_next_token() -> bool:
 	if _is_whitespace(char):
 		if _stream.get_column_pos() == 0:
 			# Identation
-			_read_identation()
+			_read_indentation()
 		else:
 			# Whitespace
 			_read_whitespace()
@@ -166,6 +166,8 @@ func _read_next_token() -> bool:
 		_read_string()
 	elif char == "$":
 		_read_node_path()
+	elif char == "@":
+		_read_annotation()
 	elif _is_digit(char):
 		# Number(literal)
 		_read_number()
@@ -179,8 +181,8 @@ func _read_next_token() -> bool:
 	return true
 
 
-func _read_identation() -> void:
-	_add_identation(_read_while(_is_whitespace).length())
+func _read_indentation() -> void:
+	_add_indentation(_read_while(_is_whitespace).length())
 
 
 func _read_whitespace() -> void:
@@ -229,6 +231,11 @@ func _read_node_path() -> void:
 		_stream.get_next()
 	
 	_add_node_path(str)
+
+
+func _read_annotation() -> void:
+	_stream.get_next()  # skip @ prefix
+	_add_annotation("@" + _read_while(_is_valid_identifier))
 
 
 func _read_operator() -> void:
@@ -293,11 +300,11 @@ func _is_digit(char : String) -> bool:
 
 func _is_valid_identifier(char : String) -> bool:
 	return TextServerManager.get_primary_interface().is_valid_letter(char.unicode_at(0)) or IDENTIFIER_CHARACTERS.contains(char)
-	#return char.is_valid_unicode_identifier() or char == "@" #TODO: Godot 4.4
+	#return char.is_valid_unicode_identifier() #TODO: Godot 4.4
 
 
 func _is_keyword(token : String) -> bool:
-	return KEYWORDS.has(token) or token.begins_with("@export")
+	return KEYWORDS.has(token)
 
 
 func _is_literal(token : String) -> bool:
@@ -335,6 +342,10 @@ func _add_node_path(str : String) -> void:
 	_add_token(Token.Type.NODE_PATH, str)
 
 
+func _add_annotation(str : String) -> void:
+	_add_token(Token.Type.ANNOTATION, str)
+
+
 func _add_punctuator(punctuator : String) -> void:
 	_add_token(Token.Type.PUNCTUATOR, punctuator)
 
@@ -351,8 +362,8 @@ func _add_whitespace(str : String) -> void:
 	_add_token(Token.Type.WHITESPACE, str, false)
 
 
-func _add_identation(identation : int) -> void:
-	_add_token(Token.Type.IDENTATION, "\t".repeat(identation))
+func _add_indentation(indentation : int) -> void:
+	_add_token(Token.Type.INDENTATION, "\t".repeat(indentation))
 
 
 func _add_line_break() -> void:
@@ -400,11 +411,11 @@ class Line:
 	func get_hint_args(hint : String) -> String:
 		return hints.get(hint, "")
 	
-	func get_identation() -> int:
-		return 0 if !tokens or tokens[0].type != Token.Type.IDENTATION else tokens[0].get_value().length()
+	func get_indentation() -> int:
+		return 0 if !tokens or tokens[0].type != Token.Type.INDENTATION else tokens[0].get_value().length()
 	
 	func has_statement() -> bool:
-		var t : int = 0 if get_identation() == 0 else 1
+		var t : int = 0 if get_indentation() == 0 else 1
 		return tokens.size() >= t + 1 and !tokens[t].is_comment() and !tokens[t].is_line_break()
 	
 	func has_token_value(value : String) -> bool:

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -214,7 +214,7 @@ func _read_string() -> void:
 			break
 		str += char
 	
-	_add_string_literal(end + str + end)
+	_add_string_literal(str, end)
 	_can_be_nodepath = false
 
 
@@ -325,8 +325,8 @@ func _is_literal(token : String) -> bool:
 	return LITERALS.has(token)
 
 
-func _add_token(type : Token.Type, value : String, readable : bool = true) -> void:
-	var token := Token.new(type, value, _tokens.size(), _output.size()-1)
+func _add_token(type : Token.Type, value : String, readable : bool = true, deco : String = "") -> void:
+	var token := Token.new(type, value, _tokens.size(), _output.size()-1, deco)
 	_output.back().add_token(token)
 	if readable:
 		_tokens.append(token)
@@ -348,8 +348,8 @@ func _add_number_literal(number : String) -> void:
 	_add_token(Token.Type.NUMBER_LITERAL, number)
 
 
-func _add_string_literal(str : String) -> void:
-	_add_token(Token.Type.STRING_LITERAL, str)
+func _add_string_literal(str : String, deco : String) -> void:
+	_add_token(Token.Type.STRING_LITERAL, str, true, deco)
 
 
 func _add_node_path(str : String) -> void:

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -416,7 +416,7 @@ class Line:
 	func clear_tokens(keep_identation : bool = true) -> void:
 		for i in range(tokens.size() - 1, -1, -1):
 			var token : Token = tokens[i]
-			if !token.is_line_break() and (!keep_identation or !token.is_identation()):
+			if !token.is_line_break() and (!keep_identation or !token.is_indentation()):
 				tokens.remove_at(i)
 	
 	func add_hint(hint : String, args : String) -> void:

--- a/addons/gdmaim/settings.gd
+++ b/addons/gdmaim/settings.gd
@@ -11,6 +11,7 @@ enum GDScriptExportMode {
 
 var obfuscation_enabled : bool = true
 var shuffle_top_level : bool = true
+var inline_statements : bool = true
 var inline_constants : bool = true
 var inline_enums : bool = true
 var obfuscate_export_vars : bool = true
@@ -52,6 +53,7 @@ func _init() -> void:
 	add_entry("obfuscate_export_vars", "export_vars", "Obfuscate Export Vars", "If true, obfuscate export variables.\nNote: Requires scenes and resources which modify custom export vars to be saved as '*.tscn' and '*.tres', respectively.")
 	#add_entry("obfuscate_signals", "signals", "Obfuscate Signals", "If true, obfuscate signals.")
 	add_entry("shuffle_top_level", "shuffle_top_level", "Shuffle Top-Level Declarations", "If true, shuffles all top-level declarations of variables, functions, signals, etc.")
+	add_entry("inline_statements", "inline_code", "Inline Statements", "If true, aggressively merge multiple lines of statements into single lines")
 	add_entry("inline_constants", "inline_consts", "Inline Constants", "If true, replace constants with hardcoded values.\nNote: Only bool, int, float, Color, Vector(2/3/4)(i) and NodePath are supported.").disabled = true
 	add_entry("inline_enums", "inline_enums", "Inline Enums", "If true, replace enums with hardcoded values.").disabled = true
 	add_entry("preprocessor_prefix", "preprocessor_prefix", "Preprocessor Prefix", "Sets the prefix to use for preprocessor hints.")

--- a/addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd
+++ b/addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd
@@ -215,7 +215,9 @@ func _setup_syntax_highlighter() -> void:
 	for keyword in ["if", "else", "elif", "for", "in", "while", "return", "continue", "break", "pass", "match", "case"]:
 		syntax_highlighter.add_keyword_color(keyword, Color("#ff8ccc"))
 	
-	for keyword in ["tool", "export", "export_range", "onready", "rpc"]:
+	for keyword in [
+		"export", "export_category", "export_color_no_alpha", "export_custom", "export_dir", "export_enum", "export_exp_easing", "export_file", "export_flags", "export_global_dir", "export_global_file", "export_group",
+		"export_multiline", "export_node_path", "export_placeholder", "export_range", "export_storage", "export_subgroup", "icon", "onready", "rpc", "static_unload", "tool", "warning_ignore"]:
 		syntax_highlighter.add_keyword_color(keyword, Color("#ffb373"))
 	
 	for keyword in ["void", "bool", "int", "float", "String", "Array", "Dictionary", "Vector2", "Vector2i", "Vector3", "Vector3i", "Vector4", "Vector4i", "Transform2D", "Transform3D", "Quaternion", "Basis"]:

--- a/addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd
+++ b/addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd
@@ -220,7 +220,9 @@ func _setup_syntax_highlighter() -> void:
 		"export_multiline", "export_node_path", "export_placeholder", "export_range", "export_storage", "export_subgroup", "icon", "onready", "rpc", "static_unload", "tool", "warning_ignore"]:
 		syntax_highlighter.add_keyword_color(keyword, Color("#ffb373"))
 	
-	for keyword in ["void", "bool", "int", "float", "String", "Array", "Dictionary", "Vector2", "Vector2i", "Vector3", "Vector3i", "Vector4", "Vector4i", "Transform2D", "Transform3D", "Quaternion", "Basis"]:
+	for keyword in ["void", "bool", "int", "float", "String", "Array", "Dictionary", "Vector2", "Vector2i", "Vector3", "Vector3i", "Vector4", "Vector4i", "Transform2D", "Transform3D", "Quaternion", "Basis", "Callable",
+		"Variant", "PackedInt32Array", "PackedInt64Array", "PackedVector2Array", "PackedVector3Array", "PackedVector4Array", "PackedStringArray", "PackedByteArray", "PackedColorArray", "PackedFloat32Array",
+		"PackedFloat64Array", "AABB", "Color", "NodePath", "Plane", "Projection", "Rect2", "Rect2i", "RID", "Signal", "StringName", "Object"]:
 		syntax_highlighter.add_keyword_color(keyword, Color("#42ffc2"))
 	
 	source_code.syntax_highlighter = syntax_highlighter


### PR DESCRIPTION
Following some refactors of the Inline Statements PR, I have updated my own fork with a few enhancements and bug fixes, here is the outline of all of the changes

### Lamba functions, if defined within some brackets, will follow the indentation level of the opening bracket

Below is valid GDScript code. Notice how `func(child:Node):` is not followed by code that is indented further right, it uses the indentation from the previous line, where `(` opened.

Similarly in `funcs` it is possible to make the lambdas indent be more than its body or even less (back to the root) when the surrounding indents would suggest otherwise.
```gdscript
func _ready() -> void:
	if Engine.is_editor_hint():
		get('').connect(
			func(child:Node):
			if child is StateChartState and get('').is_empty():
				(
					func():
					child = get('')
				).call_deferred()
		)
	
	var funcs = [
			func(child:Node):
		print(child),
func(child:Node):
		print(child),
	]
```

Before the changes, some local variables would get lost (notice the `child` variable) and inline statements would merge the lines incorrectly thinking that the `_ready()` body ended in the middle of `funcs`
```gdscript
func _ready()->void:if Engine.is_editor_hint():get('').connect(func(hypFHZ6u:Node):if child is hypWl6Lt and get('').is_empty():(func():child=get('')).call_deferred())
	var hyplvHsy=[func(hyp5_TMO:Node):print(child),func(hypeTbLo:Node):print(hypeTbLo),]
```

With respect to bracket opening and closing, indentation level can be inherited to subsequent lines of code.
```gdscript
func _ready()->void:
	if Engine.is_editor_hint():get('').connect(func(hypTYSLK:Node):if hypTYSLK is hypCwBDt and get('').is_empty():(func():hypTYSLK=get('')).call_deferred())
	var hypVXcuY=[func(hypW8UfY:Node):print(hypW8UfY),func(hyp1gBRM:Node):print(hyp1gBRM),]
```

The Syntax Tree of the code after all changes is
```
func _ready:void
>   if
>   >   symbol Engine.is_editor_hint
>   >   symbol get
>   >   symbol connect
>   >   func @lambda
>   >   >   param child:Node
>   >   >   if
>   >   >   >   symbol child.is.StateChartState
>   >   >   >   symbol get
>   >   >   >   symbol is_empty
>   >   >   >   func @lambda
>   >   >   >   >   symbol child
>   >   >   >   >   symbol get
>   >   >   >   symbol call_deferred
>   var funcs
>   >   func @lambda
>   >   >   param child:Node
>   >   >   symbol print
>   >   >   symbol child
>   >   func @lambda
>   >   >   param child:Node
>   >   >   symbol print
>   >   >   symbol child
```

---

### `%` prefixed node paths were not detected as node paths

This is an issue brought up on https://github.com/cherriesandmochi/gdmaim/issues/40. Node paths previously were only detected via the `$` prefix, therefore `%` was treated like an operator with a symbol to the right of it.
```gdscript
enum SameNameAsANode {A,B}

func test() -> SameNameAsANode:
	return SameNameAsANode.A if %SameNameAsANode.visible else SameNameAsANode.B
```

Hence the code would obfuscate the node name.
```gdscript
enum hypsgR1b{hyppByVe,hypSomda};func hypai_Wv()->hypsgR1b:return hypsgR1b.hyppByVe if%hypsgR1b.visible else hypsgR1b.hypSomda
```

By basic trial an error in the Godot Editor I've added a condition that can check whether the `%` will be a node path or an operator. Certain tokens that go before `%` are allowed and make it a node path, other tokens interpret it as an operator.
```gdscript
enum hypUHql5{hypcKNQE,hyp9Z_n_};func hyp1okL7()->hypUHql5:return hypUHql5.hypcKNQE if %SameNameAsANode.visible else hypUHql5.hyp9Z_n_
```

The final Syntax Tree of this code is
```
enum SameNameAsANode
>   key A
>   key B
func test:SameNameAsANode
>   symbol SameNameAsANode.A
>   symbol visible
>   symbol SameNameAsANode.B
```

This fixes cherriesandmochi/gdmaim#40.

---

### Getters and Setters were not being parsed like functions of a variable, so the AST hierarchy was lost

Although not a breaking issue, this meant that minor things, such as the parameter in the setter, would not be obfuscated.
```gdscript
var video_resolution : String = "native" :  ##LOCK_SYMBOLS
	set(x):
		video_resolution = x
		if not update_engine_values: return
		string_changed.emit(&"video_resolution", x)
		if video_window == 2:
			get_window().size = _parse_resolution(x)
```

The `x` is still visible in this snippet that was generated with gdmaim before the changes
```gdscript
var video_resolution:String="native":
	set(x):
		video_resolution=x;if not hyp0NCHh:return
		hyphPbC2.emit(&"video_resolution",x);if video_window==2:get_window().size=hype6Buf(x)
```

A change was implemented into variables so they could store a list of symbols that are used in the default definition (cleaner AST) as well as a sequence of functions that can take a getter or setter without the `func` keyword
```gdscript
var video_resolution:String="native":
	set(hypEYXXqd):
		video_resolution=hypEYXXqd;if not hyprbiOa:return
		hypjxvet.emit(&"video_resolution",hypEYXXqd);if video_window==2:get_window().size=hypGnrjQ(hypEYXXqd)
```

The final Syntax Tree of this code is
```
var video_resolution:String
>   func set
>   >   param x
>   >   symbol video_resolution
>   >   symbol x
>   >   if
>   >   >   symbol update_engine_values
>   >   symbol string_changed.emit
>   >   symbol x
>   >   if
>   >   >   symbol video_window
>   >   >   symbol get_window
>   >   >   symbol size
>   >   >   symbol _parse_resolution
>   >   >   symbol x
```

---

### Statement breaks `\` were not detected by Inline Statements and would not be properly respected

I've checked the Tokenizer and noticed that the `\` symbol would get skipped along with a newline, which is fine until there are comments separating the parts of the statement. This resulted in some code that failed to compile, such as from using the GodotStateCharts addon.
```gdscript
	for transition in _transitions:
		# the currently pending transition is not replaced by itself
		if transition != _pending_transition \
			# automatic transitions are always evaluated
			# non-automatic only if this evaluation was not triggered
			# by property change AND their event matches their current event
			and (not transition.has_event or (not property_change and transition.event == event)) \
			# and in every case the guard needs to match
			and transition.evaluate_guard():
				# print(name +  ": consuming event " + event)
				# first match wins
				_run_transition(transition)
				return true
```

This should have been in one line, but due to how the Statement Break was processed it would result in split code
```gdscript
	for hyptwvHd in _transitions:if hyptwvHd!=hyp2_nnZ 
			and(not hyptwvHd.hypoUjH3 or(not hypygQy6 and hyptwvHd.hypDaWtiz==hypxCVLL));and hyptwvHd.hypUPjIF():hyp_oZoT(hyptwvHd);return true
```

I've extended the Token types to support Statement Breaks. Since it also meant potentially breaking the Parser, I updated the Parser to respect statement breaks and inherit the indentation level similarly to what happens when a lambda function gets defined inside of brackets.
```gdscript
for hypwACTE in _transitions:if hypwACTE!=hypzErUk  and(not hypwACTE.hypE1ioJ or(not hypsfNM9 and hypwACTE.hyp1fABoC==hypM7Jer)) and hypwACTE.hypmn2mW():hypQObQl(hypwACTE);return true
```

The final Syntax Tree of this code is
```
>   for
>   >   iterator transition
>   >   symbol _transitions
>   >   if
>   >   >   symbol transition
>   >   >   symbol _pending_transition
>   >   >   symbol transition.has_event
>   >   >   symbol property_change
>   >   >   symbol transition.event
>   >   >   symbol event
>   >   >   symbol transition.evaluate_guard
>   >   >   symbol _run_transition
>   >   >   symbol transition
```

Notice for improvement: `\` will always add a space, it does not check if the space can be omitted at the moment.

---

### `@export_node_path` types would not get obfuscated

Originally brought up in https://github.com/cherriesandmochi/gdmaim/issues/42#issue-2797586402. Annoyingly `@export_node_path` takes types as a string, not an unquoted symbol. This meant that a String literal would need to sync its value or name the same way as Symbols do, which they didn't before,
```gdscript
class_name HistoryState
extends StateChartState

@export_node_path("StateChartState") var default_state:NodePath:
	set(value):
		default_state = value
		update_configuration_warnings()
```

Hence the `extends` obfuscates but the `@export_node_path` doesn't and it results in code that errors in console.
```gdscript
class_name hypdHL8U extends hypWl6Lt
@export_node_path("StateChartState")var hyptYF7UZ:NodePath:
	set(value):hyptYF7UZ=value;update_configuration_warnings()
```

To fix this I've made tokens support "decorators", which are both a prefix and suffix. Useful for strings that need the same symbol (or group of symbols) from either side. This simplified some code related to string obfuscation and made syncing values easier as the decorator can stay unchanged whilst the value updates.
```gdscript
class_name hypUuIes extends hypCwBDt
@export_node_path("hypCwBDt")var hypcHVnFH:NodePath:
	set(hypMuwzC):hypcHVnFH=hypMuwzC;update_configuration_warnings()
```

The final Syntax Tree of this code is
```
@export_node_path var default_state:NodePath
>   symbol "StateChartState"
>   func set
>   >   param value
>   >   symbol default_state
>   >   symbol value
>   >   symbol update_configuration_warnings
```

Fixes cherriesandmochi/gdmaim#42.

---

Apologies for the wall of text haha

This PR includes commits from cherriesandmochi/gdmaim#38