### PR TITLE
Fixed plugin compatibility with Godot 4.4.1

### DIFF
--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -134,7 +134,8 @@ func _export_begin(features : PackedStringArray, is_debug : bool, path : String,
 	var class_cache := ConfigFile.new()
 	var class_cache_src : PackedByteArray = FileAccess.get_file_as_bytes(GODOT_CLASS_CACHE_PATH)
 	class_cache.parse(class_cache_src.get_string_from_utf8())
-	var classes : Array[Dictionary] = class_cache.get_value("", "list")
+	var classes : Array[Dictionary] = []
+	classes.assign(class_cache.get_value("", "list"))
 	for class_data : Dictionary in classes:
 		if _class_symbols.has(class_data.class):
 			class_data.class = StringName(_class_symbols[class_data.class].get_name())


### PR DESCRIPTION
This is a very simple change just to keep compatibility with Godot 4.4.1. Maybe also affects Godot 4.4, didn't test.

Essentially, since an untyped array can't be assigned directly to a typed array variable, we have to use the `.assign()` method to move one into the other. In Godot 4.4.1 this causes a script error during export which mangles the exported game, but with this it works just the same as before.