### PR TITLE
Add option to strip editor-only annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ To configure this plugin, open the GDMaim dock on the bottom left, right next to
 
 `Strip Extraneous Spacing`: If enabled, spaces and tabs that are not required, get removed.
 
+`Strip Editor Annotations`: If enabled, annotations used exclusively by the editor will be removed.
+
 `Strip Lines Matching RegEx`: If enabled, any lines matching the regular expression will be removed.
 
 `Process Feature Filters`: If enabled, process automatic filtering of code, based on export template feature tags. For more information, see [feature filters](#preprocessor-hints).

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -259,7 +259,7 @@ func _strip_code() -> void:
 	for l in range(lines.size() - 1, -1, -1):
 		var line : Tokenizer.Line = lines[l]
 		
-		if _Settings.current.strip_comments or _Settings.current.strip_extraneous_spacing:
+		if _Settings.current.strip_comments or _Settings.current.strip_extraneous_spacing or _Settings.current.strip_editor_annotations:
 			for i in range(line.tokens.size() - 1, -1, -1):
 				var token : Token = line.tokens[i]
 				
@@ -278,6 +278,25 @@ func _strip_code() -> void:
 						var next_type : int = line.tokens[i+1].type if i+1 < line.tokens.size() else Token.Type.NONE
 						if i == 0 or prev_type == Token.Type.OPERATOR or prev_type == Token.Type.PUNCTUATOR or next_type == Token.Type.OPERATOR or next_type == Token.Type.PUNCTUATOR:
 							line.remove_token(i)
+							continue
+				
+				# Strip annotations used exclusively by the editor
+				if _Settings.current.strip_editor_annotations:
+					if token.is_annotation():
+						# These annotations can only be on their own line
+						if token.get_value() in ["@export_category", "@export_group", "@export_subgroup"]:
+							tokenizer.remove_output_line(l)
+							continue
+						# Other @export's and a few others might have parenthesis after them, with whitespace possibly after the parenthesis
+						elif token.get_value().contains("@export") or token.get_value() in ["@icon", "@tool", "@warning_ignore"]:
+							line.remove_token(i)
+							if line.tokens.size() > i and line.tokens[i].is_punctuator("("):
+								var last_token: Token
+								while line.tokens.size() > i:
+									last_token = line.tokens[i]
+									line.remove_token(i)
+									if last_token.is_punctuator(")"): break
+							while line.tokens.size() > i and line.tokens[i].is_whitespace(): line.remove_token(i)
 							continue
 		
 		# Strip empty lines

--- a/addons/gdmaim/settings.gd
+++ b/addons/gdmaim/settings.gd
@@ -23,6 +23,7 @@ var symbol_dynamic_seed : bool = false
 var strip_comments : bool = true
 var strip_empty_lines : bool = true
 var strip_extraneous_spacing : bool = true
+var strip_editor_annotations : bool = true
 var feature_filters : bool = true
 var regex_filter_enabled : bool = true
 var regex_filter : String = ""
@@ -60,6 +61,7 @@ func _init() -> void:
 	add_entry("strip_comments", "strip_comments", "Strip Comments", "If true, remove all comments.")
 	add_entry("strip_empty_lines", "strip_empty_lines", "Strip Empty Lines", "If true, remove all empty lines.")
 	add_entry("strip_extraneous_spacing", "strip_extraneous_spacing", "Strip Extraneous Spacing", "If true, remove all irrelevant spaces and tabs.")
+	add_entry("strip_editor_annotations", "strip_editor_annotations", "Strip Editor Annotations", "If true, remove all annotations used by the editor.")
 	add_entry("regex_filter_enabled", "regex_filter_enabled", "Strip Lines Matching RegEx", "If true, any lines matching the regular expression will be removed from the obfuscated code.")
 	add_entry("regex_filter", "regex_filter", "", "Enter Regular Expression")
 	add_entry("feature_filters", "feature_filters", "Process Feature Filters", "If true, export template feature tags may be used to filter code.")


### PR DESCRIPTION
This pr adds a checkbox in the settings to strip annotations from the source code which are only useful in the context of the editor, which is most of them. The engine will still assign the values saved in the scene file at runtime, even without the ```@export``` annotations.

I did encounter one single issue with the feature, which I believe is on the engine side of things. If you create a scene and ```@export``` variables in a script, instantiate the scene in another scene, replace the script with another one that has variables with the same names (e.g. replace instantiated scene's script with one that extends the class of the original one), and leave them at default values, the engine will not load the variables from the scene without the ```@export``` annotation. My solution was to unset the values from the child scene, and set them in the parent scene. Even if you need to ```@export``` a node, you can turn on editable children on the instantiated scene, assign the node to the variable, turn off editable children and it will stay set.

Closes https://github.com/cherriesandmochi/gdmaim/issues/41