### PR TITLE
Add missing Vector*i constants

### DIFF
--- a/addons/gdmaim/builtins.gd
+++ b/addons/gdmaim/builtins.gd
@@ -1053,6 +1053,10 @@ const VARIANTS : Array[Dictionary] = [
 	},
 	{
 		"class": "Vector2i",
+		"constants": [
+			"MIN",
+			"MAX",
+		],
 	},
 	{
 		"class": "Vector3",


### PR DESCRIPTION
Vector*i Variants have additional MIN and MAX constants.