### PR TITLE
Obfuscation placeholder support

### DIFF
--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -105,7 +105,7 @@ func _string_obfuscation(token : Token) -> void:
 
 	var placeholders : String = get_placeholders(str) if "%" in str else ""
 
-	token.set_value(_symbol_table.obfuscate_string_global(str))
+	token.set_value(_symbol_table.obfuscate_string_global(str) + placeholders)
 
 
 func get_placeholders(str: String) -> String:

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -133,9 +133,12 @@ func _string_obfuscation(token : Token) -> void:
 			for idx : int in range(0, fragments.size(), 1):
 				var fragment : String = fragments[idx]
 				
-				if fragment.is_empty():
-					continue
-					
+				# avoid obfuscating whitespace-only strings
+				var text : String = fragment.strip_edges()
+				if text.is_empty():
+					tail += fragment
+					continue		
+								
 				elif fragment == pimpampum:
 					if candy < candy_holders.size():
 						tail += candy_holders[candy]
@@ -144,26 +147,21 @@ func _string_obfuscation(token : Token) -> void:
 				
 				var str_begin : String = fragment[0]
 				var str_end : String = fragment[fragment.length() - 1]
-				
+
 				if !(str_begin in end_pray):
 					str_begin = ""
 				
 				if !(str_end in end_pray):
 					str_end = ""
-
-				# avoid obfuscating whitespace-only strings
-				if fragment.strip_edges().is_empty():
-					tail += fragment
-					continue
 				
-				tail += str(str_begin, _symbol_table.obfuscate_string_global(fragment.strip_edges()), str_end)
+				tail += str(str_begin, _symbol_table.obfuscate_string_global(text), str_end)
 			
 			for x in range(candy, candy_holders.size(), 1):
 				tail += candy_holders[x]
 				
 			# prevent set_value from removing the first character if it's % instead of a quote "
 			token.set_value("\"" + tail)
-			return			
+			return
 			
 	token.set_value(_symbol_table.obfuscate_string_global(str))
 

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -156,7 +156,7 @@ func _string_obfuscation(token : Token) -> void:
 			for x in range(candy, candy_holders.size(), 1):
 				tail += candy_holders[x]
 				
-			token.set_value(tail)
+			token.set_value("\"" + tail)
 			return			
 			
 	token.set_value(_symbol_table.obfuscate_string_global(str))

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -102,23 +102,64 @@ func _string_obfuscation(token : Token) -> void:
 		return
 	
 	var str : String = token.get_value(false)
-
-	var placeholders : String = get_placeholders(str) if "%" in str else ""
-
-	token.set_value(_symbol_table.obfuscate_string_global(str) + placeholders)
-
-
-func get_placeholders(str: String) -> String:
-	var regex := RegEx.new()
-	regex.compile("%[-+0-9.]*[a-zA-Z]")
-
-	var results := []
-	var matches = regex.search_all(str)
-
-	for match in matches:
-		results.append(match.get_string())
-
-	return "".join(results)
+	
+	var regex : RegEx = RegEx.create_from_string("(%[\\d\\.]*[a-zA-Z]|\\{\\d+\\})", false)
+	if regex.is_valid():
+		var fragments : PackedStringArray = []
+		var candy_holders : PackedStringArray = []
+		var last_candy_idx : int = 0
+		var pimpampum : String = "__HOCUSPOCUS__"
+	
+		var matches : Array[RegExMatch] = regex.search_all(str)
+		for rmatch in matches:
+			var text_before : String = str.substr(last_candy_idx, rmatch.get_start() - last_candy_idx)
+			
+			fragments.append(text_before)
+			fragments.append(pimpampum)
+			candy_holders.append(rmatch.get_string())			
+			
+			last_candy_idx = rmatch.get_end()
+		
+		if candy_holders.size() > 0:	
+			var candy : int = 0
+			var end_pray : PackedStringArray = [" ", "\t", "\n"] # wilwilwilcard String!
+			var tail : String = str.substr(last_candy_idx)
+			
+			if !tail.is_empty():
+				fragments.append(tail)
+			
+			tail = ""
+				
+			for idx : int in range(0, fragments.size(), 1):
+				var fragment : String = fragments[idx]
+				
+				if fragment.is_empty():
+					continue
+					
+				elif fragment == pimpampum:
+					if candy < candy_holders.size():
+						tail += candy_holders[candy]
+						candy += 1
+					continue
+				
+				var str_begin : String = fragment[0]
+				var str_end : String = fragment[fragment.length() - 1]
+				
+				if !(str_begin in end_pray):
+					str_begin = ""
+				
+				if !(str_end in end_pray):
+					str_end = ""
+				
+				tail += str(str_begin, _symbol_table.obfuscate_string_global(fragment.strip_edges()), str_end)
+			
+			for x in range(candy, candy_holders.size(), 1):
+				tail += candy_holders[x]
+				
+			token.set_value(tail)
+			return			
+			
+	token.set_value(_symbol_table.obfuscate_string_global(str))
 
 
 func _string_param_obfuscation(token : Token, next_token : Token) -> void:

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -102,7 +102,23 @@ func _string_obfuscation(token : Token) -> void:
 		return
 	
 	var str : String = token.get_value(false)
+
+	var placeholders : String = get_placeholders(str) if "%" in str else ""
+
 	token.set_value(_symbol_table.obfuscate_string_global(str))
+
+
+func get_placeholders(str: String) -> String:
+	var regex := RegEx.new()
+	regex.compile("%[-+0-9.]*[a-zA-Z]")
+
+	var results := []
+	var matches = regex.search_all(str)
+
+	for match in matches:
+		results.append(match.get_string())
+
+	return "".join(results)
 
 
 func _string_param_obfuscation(token : Token, next_token : Token) -> void:

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -150,12 +150,18 @@ func _string_obfuscation(token : Token) -> void:
 				
 				if !(str_end in end_pray):
 					str_end = ""
+
+				# avoid obfuscating whitespace-only strings
+				if fragment.strip_edges().is_empty():
+					tail += fragment
+					continue
 				
 				tail += str(str_begin, _symbol_table.obfuscate_string_global(fragment.strip_edges()), str_end)
 			
 			for x in range(candy, candy_holders.size(), 1):
 				tail += candy_holders[x]
 				
+			# prevent set_value from removing the first character if it's % instead of a quote "
 			token.set_value("\"" + tail)
 			return			
 			


### PR DESCRIPTION
This change updates the string obfuscation logic to preserve format placeholders (such as `%s`, `%d`, `%f,` `%02x`, etc.) when using `##OBFUSCATE_STRINGS` on string literals.

Previously, `##OBFUSCATE_STRINGS` would obfuscate the entire string, removing placeholders and causing runtime errors when using the `%` operator.

**Examples**

Original code
<img width="475" height="96" alt="image" src="https://github.com/user-attachments/assets/b9465d99-4022-4916-829a-757d66a7b8bb" />

Obfuscated code
<img width="266" height="56" alt="image" src="https://github.com/user-attachments/assets/7ce8dc50-221a-4d01-bed6-83b407bff0c1" />
