### PR TITLE
Allows you to add custom tokens to prevent them from being obfuscated.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .godot/
 *.import
 *.txt
+**/~*
 *_legacy*
 export.cfg
 project.godot

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Once you have enabled the plugin, you should go to: `res://addons/gdmaim/user/ig
 The tokens must be entered as a list.
 
 For example:
-```js
+```py
 # Token List
 my_custom_variable_name
 my_special_func

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A plugin for the [Godot Engine] which obfuscates all GDScripts when exporting a 
 	- [Source map viewer](#source-map-viewer)
 	- [Export template feature tags](#export-template-feature-tags)
 	- [Preprocessor hints](#preprocessor-hints)
+	- [Custom Ignore Tokens](#custom-ignore-tokens)
 - [Limitations and caveats](#limitations-and-caveats-)
 - [Stability](#stability-)
 - [External Libraries](#external-libraries-)
@@ -255,6 +256,32 @@ func server_func() -> int:
 func __Dg8o() -> int:
   printerr("ERROR: illegal call to 'test.__Dg8o'!")
   return 0
+```
+
+### Custom Ignore Tokens
+You can enter your own tokens to prevent them from being obfuscated. 
+Once you have enabled the plugin, you should go to: `res://addons/gdmaim/user/ignore_tokens.txt`
+
+The tokens must be entered as a list.
+
+For example:
+```js
+# Token List
+my_custom_variable_name
+my_special_func
+my_another_special_func
+my_class
+
+# More examples
+health_value
+show_game_core
+start_game
+game_over
+GamePlayer
+UserData
+GodotClass
+# ...
+
 ```
 
 ## Limitations and caveats [↑](#table-of-contents)

--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -110,6 +110,16 @@ func _export_begin(features : PackedStringArray, is_debug : bool, path : String,
 			_symbols.lock_symbol_name(var_)
 		for func_ in variant.get("methods", []):
 			_symbols.lock_symbol_name(func_)
+			
+	if settings.use_custom_token_ignore_file:
+		var file : String = settings.custom_token_ignore_file_path
+		if FileAccess.file_exists(file):
+			var packed : PackedStringArray = FileAccess.get_file_as_string(file).split("\n")
+			for smb in packed:
+				smb = smb.strip_edges()
+				if smb.is_empty() or smb.begins_with("#"):
+					continue
+				_symbols.lock_symbol_name(smb)
 	
 	# Gather built-in class symbols
 	for class_ in ClassDB.get_class_list():

--- a/addons/gdmaim/plugin.cfg
+++ b/addons/gdmaim/plugin.cfg
@@ -3,5 +3,5 @@
 name="GDMaim - GDScript Obfuscator"
 description="Automatically obfuscates GDscripts during export."
 author="cherriesandmochi"
-version="0.2.0"
+version="0.2.1-dev"
 script="plugin.gd"

--- a/addons/gdmaim/plugin.gd
+++ b/addons/gdmaim/plugin.gd
@@ -32,6 +32,7 @@ func _enter_tree() -> void:
 	source_map_viewer.hide()
 	get_editor_interface().get_base_control().add_child(source_map_viewer)
 
+	_setup()
 
 # Called when exiting scene tree
 func _exit_tree() -> void:
@@ -53,3 +54,14 @@ func _open_source_map_viewer() -> void:
 		source_map_viewer.hide()
 	else:
 		source_map_viewer.popup_centered_clamped(source_map_viewer.size, 0.95)
+
+
+# Pre-validations
+func _setup() -> void:
+	var file : String = settings.custom_token_ignore_file_path
+	if !file.is_empty():
+		if !FileAccess.file_exists(file):
+			var fs : FileAccess = FileAccess.open(file, FileAccess.WRITE)
+			if is_instance_valid(fs):
+				fs.store_string("# Here place you custom tokens, must be a list of tokens.\n# For example check the readme in 'https://github.com/cherriesandmochi/gdmaim' <3")
+				fs.close()

--- a/addons/gdmaim/settings.gd
+++ b/addons/gdmaim/settings.gd
@@ -37,6 +37,8 @@ var debug_resources : PackedStringArray
 var obfuscate_debug_only : bool = false
 var export_mode : int = GDScriptExportMode.TEXT
 
+var use_custom_token_ignore_file : bool = false
+var custom_token_ignore_file_path : String = "res://addons/gdmaim/user/ignore_tokens.txt"
 var exclude_files : PackedStringArray = []
 var _exclude_files : String = "":
 	set(value):
@@ -93,6 +95,7 @@ func _init() -> void:
 	set_category("exclude_files_category", "Exclusion")
 	add_entry("_exclude_files", "multi_filepath", "Path", "Select files or folders to be excluded from obfuscation; excluded scripts will maintain compatibility with the other obfuscated scripts.").set_custom_type(Entry.CustomType.MULTI_FILE_PATH, "")
 	add_entry("exclude_resources", "resources", "Exclude Resources", "If true, resources like PackedScenes will be ignored during scanning.\nThis is useful if you typically have a lot of embedded resources in your resources and causing problems such as freezing.\n\n(WARNING) This could cause errors if you reference scripts within your packaged scenes, such as signals or exported variables. (Source of embedded scripts are the exception)\n\nRemember that this can be solved by following the best practices recommended in the official repository.")
+	add_entry("use_custom_token_ignore_file", "custom_tokens_enabled", "Custom Token File", "If true, any token defined by you in\n'{0}'\nwill be ignored".format([custom_token_ignore_file_path]))
 	
 	#set_category("debug", "Debug")
 	#add_entry("debug_scripts", debug_scripts", "", "")


### PR DESCRIPTION
### Custom Ignore Tokens
You can enter your own tokens to prevent them from being obfuscated. 
Once you have enabled the plugin, you should go to: `res://addons/gdmaim/user/ignore_tokens.txt`

The tokens must be entered as a list.

For example:
```PY
# Token List
my_custom_variable_name
my_special_func
my_another_special_func
my_class

# More examples
health_value
show_game_core
start_game
game_over
GamePlayer
UserData
GodotClass
# ...

```

In Setting `Custom Token File` must be enabled!