### PR TITLE
Custom String Seed Reference of #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,36 @@ var __rEyW : int
 __U5iZ("__rEyW", 3)
 ```
 
+`##OBFUSCATE_STRING_SEED arg_number`: 
+
+```js
+// In the next example we use OBFUSCATE_STRINGS_SEED preprocessor combined with OBFUSCATE_STRINGS
+
+var my_string : String = "Foo" ##OBFUSCATE_STRINGS ##OBFUSCATE_STRINGS_SEED 1000
+
+# This force use the seed '1000'
+
+// Example
+//# In the next example we use OBFUSCATE_STRINGS_SEED preprocessor combined with OBFUSCATE_STRINGS
+var my_generic_string : String = "Shared String"
+var my_obfuscated_string : String = "Shared String" ##OBFUSCATE_STRINGS
+
+// This force use the seed '1000'
+var my_obfuscated_string_by_seed : String = "Shared String" ##OBFUSCATE_STRINGS ##OBFUSCATE_STRINGS_SEED 1000
+var other_obfuscated_string : String = "Shared String" ##OBFUSCATE_STRINGS
+```
+
+=>
+
+
+```js
+var __m6KE:String="Shared String"
+var __nBLL:String="_y342"
+var __bLLP:String="_ySlQ" //# String with seed 1000
+var __knM3:String="_y342"
+```
+
+
 `##EXCLUDE_FILE`: Prevent obfuscation of the script file and it maintains match compatibility throughout the project for the scripts that can use it. put in wherever you want in your script, as a good practice, place it at the beginning of the file.
 
 ```js

--- a/addons/gdmaim/obfuscator/script/parser/parser.gd
+++ b/addons/gdmaim/obfuscator/script/parser/parser.gd
@@ -124,9 +124,7 @@ func _parse_statement(parent : AST.ASTNode) -> AST.ASTNode:
 	_statement_break = false  # Statement break persists until next non-whitespace token
 	
 	#TODO skip line break here, unless we've got a semicolon coming up next
-	
 	return node
-
 
 func _parse_statement_break() -> void:
 	_tokenizer.get_next()
@@ -487,6 +485,7 @@ func _parse_enum(parent : AST.ASTNode) -> AST.EnumDef:
 	
 	# Check if enum is Named
 	var token : Token = _tokenizer.get_next()
+	
 	if token.is_symbol():
 		ast = AST.EnumDef.new(parent)
 		ast.symbol = _symbol_table.create_global_symbol(token.get_value())
@@ -748,6 +747,7 @@ func _parse_params(parent : AST.ASTNode) -> Array[AST.Parameter]:
 		elif token.is_symbol():
 			if expect_symbol:
 				_tokenizer.get_next()
+				
 				expect_symbol = false
 				param.symbol = _symbol_table.create_local_symbol(token.get_value(), _parse_var_type(param))
 				token.link_symbol(param.symbol)

--- a/addons/gdmaim/obfuscator/script/preprocessor_hints.gd
+++ b/addons/gdmaim/obfuscator/script/preprocessor_hints.gd
@@ -6,3 +6,4 @@ const OBFUSCATE_STRINGS : String = "OBFUSCATE_STRINGS"
 const OBFUSCATE_STRING_PARAMETERS : String = "OBFUSCATE_STRING_PARAMETERS" # param0, param1, ...
 const FEATURE_FUNC : String = "FEATURE_FUNC" # feature_tag #TODO
 const EXCLUDE_HINT : String = "EXCLUDE_FILE" # prevent obfuscate the script and maintains compatibility with external uses.
+const OBFUSCATE_STRINGS_SEED : String = "OBFUSCATE_STRINGS_SEED"

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -103,7 +103,7 @@ func get_class_symbol() -> SymbolTable.Symbol:
 
 
 func _string_obfuscation(token : Token) -> void:
-	if !token.is_string_literal() or token.is_string_multiline():
+	if !token.is_string_literal():
 		return
 	
 	var str : String = token.get_value(false)

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -46,6 +46,11 @@ func run(features : PackedStringArray) -> bool:
 		var prev_line : Tokenizer.Line = tokenizer.get_output_line(token.line-1)
 		
 		if _Settings.current.obfuscation_enabled:
+			if line.has_hint(PreprocessorHints.OBFUSCATE_STRINGS_SEED):
+				_symbol_table.set_custom_seed(line.get_hint_args(PreprocessorHints.OBFUSCATE_STRINGS_SEED).to_int())
+			else:
+				_symbol_table.set_custom_seed(0)
+		
 			if line.has_hint(PreprocessorHints.OBFUSCATE_STRINGS):
 				_string_obfuscation(token)
 			_string_param_obfuscation(token, next_token)
@@ -98,7 +103,7 @@ func get_class_symbol() -> SymbolTable.Symbol:
 
 
 func _string_obfuscation(token : Token) -> void:
-	if !token.is_string_literal():
+	if !token.is_string_literal() or token.is_string_multiline():
 		return
 	
 	var str : String = token.get_value(false)

--- a/addons/gdmaim/obfuscator/symbol_table.gd
+++ b/addons/gdmaim/obfuscator/symbol_table.gd
@@ -18,6 +18,8 @@ var _id_list : PackedStringArray
 var _id_table : Dictionary
 var _unique_ids : Dictionary
 
+var _custom_seed : int = 0
+
 
 func _init(settings : _Settings) -> void:
 	self.settings = settings
@@ -34,6 +36,9 @@ func lock_symbol(symbol : Symbol) -> void:
 		_local_symbols.remove_at(lidx)
 	else:
 		lock_symbol_name(symbol.get_name())
+		
+func set_custom_seed(new_seed : int = 0) -> void:
+	_custom_seed = new_seed
 
 func create_symbol(ast_node : AST.ASTNode, name : String, type : String = "") -> Symbol:
 	if ast_node.get_parent() is AST.Sequence and ast_node.get_parent().get_parent() is AST.Class:
@@ -124,10 +129,12 @@ func resolve_symbol_paths() -> void:
 func obfuscate_symbols() -> void:
 	for symbol in _local_symbols:
 		if !_locked_symbols.has(symbol.get_name()):
+			#set_custom_seed(symbol.seed)
 			rename_symbol(symbol, _generate_symbol_name(symbol.get_name(), true))
 	
 	for symbol in _global_symbols.values():
 		if !_locked_symbols.has(symbol.get_name()):
+			#set_custom_seed(symbol.seed)
 			rename_symbol(symbol, _generate_symbol_name(symbol.get_name()))
 
 
@@ -152,29 +159,40 @@ func _search_symbol(ast_node : AST.ASTNode, name : String, is_func : bool) -> Sy
 
 
 func _generate_symbol_name(source_name : String, unique : bool = false) -> String:
-	if !unique and _id_table.has(source_name):
+	if !unique and _id_table.has(source_name) and _custom_seed == 0:
 		return _id_table[source_name]
 	
 	var random := RandomNumberGenerator.new()
-	random.seed = hash(source_name) + source_name.length() + _seed
 	
 	var target_length : int = maxi(1, settings.symbol_target_length)
 	var id : String
-	while !id or _id_list.has(id):
+	
+	if _custom_seed != 0:
+		random.seed = hash(source_name) + source_name.length() + _custom_seed
+		
 		var _id : String = settings.symbol_prefix
 		for j in target_length:
 			_id += settings.symbol_characters[random.randi() % settings.symbol_characters.length()]
-		if !id and unique and _id_list.has(_id):
-			_unique_ids[source_name] = _unique_ids.get(source_name, 0) + 1
-			random.seed += _unique_ids[source_name]
-		else:
-			target_length += 1
 		id = _id
+		
+	else:
+		random.seed = hash(source_name) + source_name.length() + _seed
 	
-	_id_list.append(id)
-	if !unique:
-		_id_table[source_name] = id
-	
+		while !id or _id_list.has(id):
+			var _id : String = settings.symbol_prefix
+			for j in target_length:
+				_id += settings.symbol_characters[random.randi() % settings.symbol_characters.length()]
+			if !id and unique and _id_list.has(_id):
+				_unique_ids[source_name] = _unique_ids.get(source_name, 0) + 1
+				random.seed += _unique_ids[source_name]
+			else:
+				target_length += 1
+			id = _id
+		
+		_id_list.append(id)
+		if !unique:
+			_id_table[source_name] = id
+		
 	return id
 
 
@@ -185,6 +203,7 @@ class Symbol extends RefCounted:
 	var children : Dictionary
 	var string_params : Array
 	var parent : Symbol
+	#var seed : int = 0
 	
 	static func new_linked(type : String, ref : Symbol) -> Symbol:
 		var symbol := Symbol.new(ref.source_name, type)

--- a/addons/gdmaim/obfuscator/symbol_table.gd
+++ b/addons/gdmaim/obfuscator/symbol_table.gd
@@ -129,12 +129,10 @@ func resolve_symbol_paths() -> void:
 func obfuscate_symbols() -> void:
 	for symbol in _local_symbols:
 		if !_locked_symbols.has(symbol.get_name()):
-			#set_custom_seed(symbol.seed)
 			rename_symbol(symbol, _generate_symbol_name(symbol.get_name(), true))
 	
 	for symbol in _global_symbols.values():
 		if !_locked_symbols.has(symbol.get_name()):
-			#set_custom_seed(symbol.seed)
 			rename_symbol(symbol, _generate_symbol_name(symbol.get_name()))
 
 
@@ -203,7 +201,6 @@ class Symbol extends RefCounted:
 	var children : Dictionary
 	var string_params : Array
 	var parent : Symbol
-	#var seed : int = 0
 	
 	static func new_linked(type : String, ref : Symbol) -> Symbol:
 		var symbol := Symbol.new(ref.source_name, type)


### PR DESCRIPTION
## Added

New preproccesor: OBFUSCATE_STRINGS_SEED

```py
# In the next example we use OBFUSCATE_STRINGS_SEED preprocessor combined with OBFUSCATE_STRINGS

var my_string : String = "Foo" ##OBFUSCATE_STRINGS ##OBFUSCATE_STRINGS_SEED 1000

# This force use the seed '1000'
```

## Why use this?

When you have all hardcoded the save data keys and want obfuscate keys without generate conflict with files saved in previous version, you just fix the seed with that preproccesor.

Take in mind this pulls is reference to #6