### PR TITLE
Rip & Tear Static Typing Option #113

### DIFF
--- a/addons/gdmaim/builtins.gd
+++ b/addons/gdmaim/builtins.gd
@@ -1099,6 +1099,9 @@ const VARIANTS : Array[Dictionary] = [
 	{
 		"class": "Key",
 	},
+	{
+		"class" : "Variant"
+	}
 ]
 const STARTER_TOKENS : PackedStringArray = [
 	"@icon", 

--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -52,6 +52,7 @@ func _get_addon_path() -> String:
 func _get_name() -> String:
 	return "gdmaim"
 
+
 func _export_begin(features : PackedStringArray, is_debug : bool, path : String, flags : int) -> void:
 	_features = features
 	_export_path = path
@@ -255,7 +256,7 @@ func _export_file(path : String, type : String, features : PackedStringArray) ->
 	if path.begins_with(_addon_path):
 		skip()
 		return
-		
+	
 	var ext : String = path.get_extension()
 	if ext == "csv":
 		skip() #HACK

--- a/addons/gdmaim/obfuscator/script/preprocessor_hints.gd
+++ b/addons/gdmaim/obfuscator/script/preprocessor_hints.gd
@@ -5,4 +5,8 @@ const LOCK_SYMBOLS : String = "LOCK_SYMBOLS"
 const OBFUSCATE_STRINGS : String = "OBFUSCATE_STRINGS"
 const OBFUSCATE_STRING_PARAMETERS : String = "OBFUSCATE_STRING_PARAMETERS" # param0, param1, ...
 const FEATURE_FUNC : String = "FEATURE_FUNC" # feature_tag #TODO
+
+# FILES HINT
 const EXCLUDE_HINT : String = "EXCLUDE_FILE" # prevent obfuscate the script and maintains compatibility with external uses.
+const STRIP_STATIC_TYPED_HINT : String = "STRIP_STATIC_TYPED_FILE" # Strip typed definitions in variables, functions and arrays of the file.
+const STRIP_STATIC_TYPED_INITIALIZED_HINT : String = "STRIP_STATIC_TYPED_FILE_INITIALIZED"

--- a/addons/gdmaim/obfuscator/script/preprocessor_hints.gd
+++ b/addons/gdmaim/obfuscator/script/preprocessor_hints.gd
@@ -10,3 +10,4 @@ const FEATURE_FUNC : String = "FEATURE_FUNC" # feature_tag #TODO
 const EXCLUDE_HINT : String = "EXCLUDE_FILE" # prevent obfuscate the script and maintains compatibility with external uses.
 const STRIP_STATIC_TYPED_HINT : String = "STRIP_STATIC_TYPED_FILE" # Strip typed definitions in variables, functions and arrays of the file.
 const STRIP_STATIC_TYPED_INITIALIZED_HINT : String = "STRIP_STATIC_TYPED_FILE_INITIALIZED"
+const STRIP_IGNORE_STATIC_TYPED_HINT : String = "STRIP_STATIC_TYPED_FILE_IGNORE"

--- a/addons/gdmaim/obfuscator/script/tokenizer/stream.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/stream.gd
@@ -7,6 +7,12 @@ var _line : int = 1
 var _col : int = 0
 
 
+func snapshot() -> RefCounted:
+	var shot : RefCounted = new(_data)
+	for x : StringName in [&"_idx", &"_line", &"_col"]:
+		shot.set(x, get(x))
+	return shot
+
 func _init(characters : String) -> void:
 	_data = characters
 
@@ -19,7 +25,6 @@ func get_next() -> String:
 	else:
 		_col += 1
 	return _data[_idx] if _idx < _data.length() else ""
-
 
 func peek(offset : int = 1) -> String:
 	return _data[_idx + offset] if _idx + offset < _data.length() else ""

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -5,12 +5,15 @@ const _Logger := preload("../../../logger.gd")
 const _Settings := preload("../../../settings.gd")
 const Token := preload("token.gd")
 const Stream := preload("stream.gd")
+const PreprocessorHints = preload("uid://bn68k5a203yof")
 
 const KEYWORDS : Array[String] = ["extends", "class_name", "setget", "const", "signal", "enum", "static", "var", "func", "class", "pass", "if", "else", "elif", "while", "for", "in", "match", "continue", "break", "return", "assert", "yield", "await", "preload", "load", "as", "and", "or", "not", "when"]
 const LITERALS : Array[String] = ["true", "false", "null", "self", "PI", "TAU", "NAN", "INF"]
 const OPERATORS : String = "+-*^/%=<>!&|~"
 const PUNCTUATORS : String = "()[]{},;:."
 const IDENTIFIER_CHARACTERS : String = "1234567890_"
+
+static var _pregex : RegEx = null
 
 var line_count : int
 
@@ -21,6 +24,10 @@ var _line : int
 var _output : Array[Line]
 var _can_be_nodepath : bool = true
 
+## PreprocessorHints
+var _stream_preprocessor : Dictionary = {}
+var _strip_static_typing : bool = false
+var _strip_static_typing_initialized : bool = false
 
 func read(source_code : String) -> void:
 	line_count = 1
@@ -29,9 +36,24 @@ func read(source_code : String) -> void:
 	_line = 0
 	_output = [Line.new()]
 	
+	_read_preprocessor(source_code)
+	
 	_stream = Stream.new(source_code)
 	while _read_next_token(): pass
 
+
+func _read_preprocessor(src : String) -> void:
+	if null == _pregex:
+		_pregex = RegEx.create_from_string("(?m)(?<=\\s|^)##STRIP_([^\\s\\n]+)((?:(?!\\n|##).)*)")
+	
+	for mtch : RegExMatch in _pregex.search_all(src):
+		_stream_preprocessor[mtch.get_string(0).trim_prefix(_Settings.current.preprocessor_prefix)] = mtch.get_string(1).strip_edges()
+	
+	_strip_static_typing = has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_HINT) or has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_INITIALIZED_HINT) or _Settings.current.strip_static_typing
+	_strip_static_typing_initialized = has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_INITIALIZED_HINT) or _strip_static_typing_initialized or _Settings.current.striped_static_typing_be_initialized
+
+func has_preprocessor(preprocessor : String) -> bool:
+	return _stream_preprocessor.has(preprocessor)
 
 func reset() -> void:
 	_idx = -1
@@ -127,8 +149,9 @@ func generate_source_code() -> String:
 	
 	return code
 	
-func _add_default_value(id: String, _class_name: StringName = &""):
+func _add_default_value(id: String) -> void:
 	var type : int = TYPE_OBJECT
+	
 	for x in TYPE_MAX:
 		if type_string(x) == id:
 			type = x
@@ -156,23 +179,42 @@ func _add_default_value(id: String, _class_name: StringName = &""):
 			_add_symbol(x)
 	
 func _is_stripped_typed(char : String) -> bool:
-	if _Settings.current.strip_static_typing and char == ":":
-		const breakers : PackedInt64Array = [Token.Type.WHITESPACE, Token.Type.INDENTATION, Token.Type.STATEMENT_BREAK]
-		
+	if _strip_static_typing and char == ":":
+		const breakers : PackedInt64Array = [Token.Type.WHITESPACE, Token.Type.INDENTATION, Token.Type.STATEMENT_BREAK, Token.Type.LINE_BREAK]
+		const snacks : PackedStringArray = ["func", "var", "const"]
 		for x in range(_tokens.size() - 2, -1, -1):
 			var tkn : Token = _tokens[x]
 			if tkn.type in breakers:
 				continue
-			if _is_keyword(tkn.get_value()) and tkn.get_value() == "var":
+			if tkn.type == Token.Type.KEYWORD and tkn.get_value() in snacks:
 				break
+			elif tkn.type == Token.Type.PUNCTUATOR:
+				if tkn.get_value() == ",":
+					continue
+				elif "([".contains(tkn.get_value()):
+					break
+				elif "{".contains(tkn.get_value()):
+					return false
+			elif tkn.type == Token.Type.OPERATOR and tkn.get_value() == "=":
+				break
+			elif tkn.type == Token.Type.NUMBER_LITERAL:
+				continue
+			elif tkn.type == Token.Type.LITERAL or tkn.type == Token.Type.SYMBOL:
+				continue
 			return false
 			
+		var candy : Stream = _stream.snapshot()
+		
 		char = _stream.peek(2)
+		
+		while _is_whitespace(char):
+			_stream.get_next()
+			char = _stream.peek()
+		
 		if char == "=":
 			_stream.get_next()
 			return true
 		else:
-			var candy : Stream = _stream.snapshot()
 			while _is_whitespace(char) or char == "\\":
 				_stream.get_next()
 				char = _stream.peek()
@@ -180,33 +222,33 @@ func _is_stripped_typed(char : String) -> bool:
 			if !char.is_empty() and !(char in ["\n\"`"]):
 				var id : String = _read_while(_is_valid_identifier)
 				if !id.is_empty():
-					if _Settings.current.striped_static_typing_be_initialized:
+					char = _stream.peek()
+					while _is_whitespace(char) or char == "\\":
+						_stream.get_next()
 						char = _stream.peek()
-						while _is_whitespace(char) or char == "\\":
-							_stream.get_next()
-							char = _stream.peek()
-							
-						if char == "[":
+						
+					if char == "[":
+						char = _stream.get_next()
+						while !char.is_empty() and char != "]":
 							char = _stream.get_next()
-							while !char.is_empty() and char != "]":
-								char = _stream.get_next()
-							
+						
+					char = _stream.peek()
+					while char != "\n" and char != "=" and (_is_whitespace(char) or char == "\\"):
+						_stream.get_next()
 						char = _stream.peek()
-						while char != "\n" and char != "=" and (_is_whitespace(char) or char == "\\"):
-							_stream.get_next()
-							char = _stream.peek()
-							
+						
+					if _strip_static_typing_initialized:
 						if char != "=":
 							_add_operator("=")
 							_add_default_value(id)
 						
 					return true
 					
-			_stream = candy
+		_stream = candy
 	return false
 
 func _post_operator() -> void:
-	if _Settings.current.strip_static_typing:
+	if _strip_static_typing:
 		if _tokens.size() > 0 and _tokens[_tokens.size() - 1].get_value() == "->":
 			var tkn : Token = _tokens.pop_back()
 			

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -126,7 +126,106 @@ func generate_source_code() -> String:
 			code += token.get_value()
 	
 	return code
+	
+func _add_default_value(id: String, _class_name: StringName = &""):
+	var type : int = TYPE_OBJECT
+	for x in TYPE_MAX:
+		if type_string(x) == id:
+			type = x
+			break
+			
+	if type == TYPE_OBJECT:
+		_add_literal("null")
+		return
+	
+	var variant : String = str(type_convert("", type))
+	
+	if variant.is_empty():
+		variant = '""'
+	
+	for x : String in variant:
+		if _is_punctuator(x):
+			_add_punctuator(x)
+		elif _is_whitespace(x):
+			continue
+		elif _is_keyword(x):
+			_add_keyword(x)
+		elif _is_literal(x):
+			_add_literal(x)
+		else:
+			_add_symbol(x)
+	
+func _is_stripped_typed(char : String) -> bool:
+	if _Settings.current.strip_static_typing and char == ":":
+		const breakers : PackedInt64Array = [Token.Type.WHITESPACE, Token.Type.INDENTATION, Token.Type.STATEMENT_BREAK]
+		
+		for x in range(_tokens.size() - 2, -1, -1):
+			var tkn : Token = _tokens[x]
+			if tkn.type in breakers:
+				continue
+			if _is_keyword(tkn.get_value()) and tkn.get_value() == "var":
+				break
+			return false
+			
+		char = _stream.peek(2)
+		if char == "=":
+			_stream.get_next()
+			return true
+		else:
+			var candy : Stream = _stream.snapshot()
+			while _is_whitespace(char) or char == "\\":
+				_stream.get_next()
+				char = _stream.peek()
+				
+			if !char.is_empty() and !(char in ["\n\"`"]):
+				var id : String = _read_while(_is_valid_identifier)
+				if !id.is_empty():
+					if _Settings.current.striped_static_typing_be_initialized:
+						char = _stream.peek()
+						while _is_whitespace(char) or char == "\\":
+							_stream.get_next()
+							char = _stream.peek()
+							
+						if char == "[":
+							char = _stream.get_next()
+							while !char.is_empty() and char != "]":
+								char = _stream.get_next()
+							
+						char = _stream.peek()
+						while char != "\n" and char != "=" and (_is_whitespace(char) or char == "\\"):
+							_stream.get_next()
+							char = _stream.peek()
+							
+						if char != "=":
+							_add_operator("=")
+							_add_default_value(id)
+						
+					return true
+					
+			_stream = candy
+	return false
 
+func _post_operator() -> void:
+	if _Settings.current.strip_static_typing:
+		if _tokens.size() > 0 and _tokens[_tokens.size() - 1].get_value() == "->":
+			var tkn : Token = _tokens.pop_back()
+			
+			for x : int in range(_output.size() - 1, -1, -1):
+				var l : Line = _output[x]
+				var y : int = l.tokens.rfind(tkn)
+				if y > -1:
+					l.tokens.remove_at(y)
+					break
+					
+			var char : String = _stream.get_next()
+			
+			while _is_whitespace(char) or char == "\\":
+				char = _stream.get_next()
+				
+			if char == ":":
+				return
+			
+			_read_while(_is_valid_identifier)
 
 func _read_next_token() -> bool:
 	if _stream.is_eof():
@@ -156,9 +255,6 @@ func _read_next_token() -> bool:
 	elif char == "#":
 		# Comment
 		_read_comment()
-	elif _is_punctuator(char):
-		# Punctuator
-		_add_punctuator(_stream.get_next())
 	elif "\"'".contains(char):
 		var multi : bool = false
 		
@@ -181,11 +277,16 @@ func _read_next_token() -> bool:
 	elif _is_operator(char):
 		# Operator
 		_read_operator()
+		_post_operator()
+		
 	elif _is_digit(char):
 		# Number(literal)
 		_read_number()
+	elif _is_punctuator(char):
+		if !_is_stripped_typed(char):
+			# Punctuator
+			_add_punctuator(_stream.get_next())
 	elif _is_valid_identifier(char):
-		# Identifier(symbol, keyword or literal)
 		_read_identifier()
 	else:
 		_stream.get_next()

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -48,9 +48,10 @@ func _read_preprocessor(src : String) -> void:
 	
 	for mtch : RegExMatch in _pregex.search_all(src):
 		_stream_preprocessor[mtch.get_string(0).trim_prefix(_Settings.current.preprocessor_prefix)] = mtch.get_string(1).strip_edges()
-	
-	_strip_static_typing = has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_HINT) or has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_INITIALIZED_HINT) or _Settings.current.strip_static_typing
-	_strip_static_typing_initialized = has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_INITIALIZED_HINT) or _strip_static_typing_initialized or _Settings.current.striped_static_typing_be_initialized
+
+	if !has_preprocessor(PreprocessorHints.STRIP_IGNORE_STATIC_TYPED_HINT):
+		_strip_static_typing = has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_HINT) or has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_INITIALIZED_HINT) or _Settings.current.strip_static_typing
+		_strip_static_typing_initialized = has_preprocessor(PreprocessorHints.STRIP_STATIC_TYPED_INITIALIZED_HINT) or _strip_static_typing_initialized or _Settings.current.striped_static_typing_be_initialized
 
 func has_preprocessor(preprocessor : String) -> bool:
 	return _stream_preprocessor.has(preprocessor)

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -5,7 +5,7 @@ const _Logger := preload("../../../logger.gd")
 const _Settings := preload("../../../settings.gd")
 const Token := preload("token.gd")
 const Stream := preload("stream.gd")
-const PreprocessorHints = preload("uid://bn68k5a203yof")
+const PreprocessorHints = preload("../preprocessor_hints.gd")
 
 const KEYWORDS : Array[String] = ["extends", "class_name", "setget", "const", "signal", "enum", "static", "var", "func", "class", "pass", "if", "else", "elif", "while", "for", "in", "match", "continue", "break", "return", "assert", "yield", "await", "preload", "load", "as", "and", "or", "not", "when"]
 const LITERALS : Array[String] = ["true", "false", "null", "self", "PI", "TAU", "NAN", "INF"]

--- a/addons/gdmaim/plugin.cfg
+++ b/addons/gdmaim/plugin.cfg
@@ -3,5 +3,5 @@
 name="GDMaim - GDScript Obfuscator"
 description="Automatically obfuscates GDscripts during export."
 author="cherriesandmochi"
-version="0.2.1-dev"
+version="0.2.2-dev"
 script="plugin.gd"

--- a/addons/gdmaim/plugin.cfg
+++ b/addons/gdmaim/plugin.cfg
@@ -3,5 +3,5 @@
 name="GDMaim - GDScript Obfuscator"
 description="Automatically obfuscates GDscripts during export."
 author="cherriesandmochi"
-version="0.2.2-dev"
+version="0.3.0-dev"
 script="plugin.gd"

--- a/addons/gdmaim/settings.gd
+++ b/addons/gdmaim/settings.gd
@@ -24,6 +24,8 @@ var strip_comments : bool = true
 var strip_empty_lines : bool = true
 var strip_extraneous_spacing : bool = true
 var strip_editor_annotations : bool = true
+var strip_static_typing : bool = false
+var striped_static_typing_be_initialized : bool = true
 var feature_filters : bool = true
 var regex_filter_enabled : bool = true
 var regex_filter : String = ""
@@ -74,6 +76,9 @@ func _init() -> void:
 	add_entry("strip_empty_lines", "strip_empty_lines", "Strip Empty Lines", "If true, remove all empty lines.")
 	add_entry("strip_extraneous_spacing", "strip_extraneous_spacing", "Strip Extraneous Spacing", "If true, remove all irrelevant spaces and tabs.")
 	add_entry("strip_editor_annotations", "strip_editor_annotations", "Strip Editor Annotations", "If true, remove all annotations used by the editor.")
+	add_entry("strip_static_typing", "strip_static_typing", "Strip Static Typing", "If true, remove all static typing like [int, String, Objects, CustomObjects, ...] take in mind this can remove the performance benefit with the static typing practice.")
+	add_entry("striped_static_typing_be_initialized", "striped_static_typing_be_initialized", "Initialize stripped typed variables", "(This action is complement of: Strip Static Typing)\nIf true, uninitalized typed variables that typed have been removed will be initialized; this will be useful for developers who frequently perform operations with these uninitialized typed variables, avoiding type definition errors.")
+	
 	add_entry("regex_filter_enabled", "regex_filter_enabled", "Strip Lines Matching RegEx", "If true, any lines matching the regular expression will be removed from the obfuscated code.")
 	add_entry("regex_filter", "regex_filter", "", "Enter Regular Expression")
 	add_entry("feature_filters", "feature_filters", "Process Feature Filters", "If true, export template feature tags may be used to filter code.")


### PR DESCRIPTION
In the following image, we let f*ck up the static typing, enjoy!

<img width="762" height="335" alt="image" src="https://github.com/user-attachments/assets/c265fd5b-6212-4ef9-ad38-e4174fa2cce2" />



#### EDIT:
> [!NOTE]
> Keep in mind that this eliminates the performance benefits of static typing for your application/game.

## Added
* Strip Static Typing: Allow remove the type definiton.
* Initialize Stripped Typed Variables: Complement of Strip Static Typing Action.

## UPDATED#02
- Handle parameters
- New preprocessors: 

The following preprocessor has the same behavior if you enable ( Strip Static Typing | Initialize Stripped Typed Variables) through configuration, but this works through a file.. (You custom filter as you like huh)
  * ``##STRIP_STATIC_TYPED_FILE``: Strip typed definitions in variables, functions and arrays of the files, same behaviour of "Strip Static Typing".
  * ``##STRIP_STATIC_TYPED_FILE_INITIALIZED``: Same behaviour of "Initialize Stripped Typed Variables".
 
### How use the new preprocessors? 
Like the other preprocessors, this  preprocessors can place it wherever you want in the file, you can use either one since they share functionality but with different results, it is not necessary to use both in the same file.

(i recommend you to place it at the beginning of the file as good practice).

> "STRIP_STATIC_TYPED_FILE_INITIALIZED | Initialize Stripped Typed Variables" Why? 
>Hey dude take in mind this prevent errors when operate with undefined variables, but if you never do operations before intialize a variable; its okey then ignore this and go.

## UPDATED#03
- New Preprocessor: 
  * ``##STRIP_STATIC_TYPED_FILE_IGNORE``: Ignore the behaviour of "Strip Static Typing" or "Initialize Stripped Typed Variables"