### PR TITLE
GDShedor: Shader Obfuscator Compatibility Support.

### DIFF
--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -560,9 +560,18 @@ func strip(path : String) -> String:
 				if _settings.has_method(&"set_buffer"):
 					var instance : Object = Engine.get_singleton(&"GDShedor")
 					var data : String = FileAccess.get_file_as_string(path)
+					instance.notification(3164312)
 					_settings.call(&"set_buffer", data)
 					instance.notification(2162314)
 					out = instance.get_data()
+					
+					var err : Variant = instance.call(&"get_error")
+					if err is int:
+						if err == OK:
+							print("[GDShedor] Export OK {0}".format([path]))
+						else:
+							out = ""
+							printerr("[GDShedor] Export Error Code {0} : {1} ".format([err, path]))
 					break
 	
 		elif _Settings.current.strip_comments:

--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -52,6 +52,11 @@ func _get_addon_path() -> String:
 func _get_name() -> String:
 	return "gdmaim"
 
+func _initialize_third_party() -> void:
+	#GDShedor
+	if Engine.has_singleton(&"GDShedor"):
+		for _settings in Engine.get_main_loop().get_nodes_in_group(&"GDShedor"):
+			_settings.call(&"disable_export_check", true)
 
 func _export_begin(features : PackedStringArray, is_debug : bool, path : String, flags : int) -> void:
 	_features = features
@@ -59,6 +64,9 @@ func _export_begin(features : PackedStringArray, is_debug : bool, path : String,
 	_source_map_filename = _export_path.get_file().get_basename() + Time.get_datetime_string_from_system().replace(":", ".") + ".gd.map"
 	_exported_script_count = 0
 	_enabled = !features.has("no_gdmaim") and settings.obfuscation_enabled # Discrepancy with the objective of this variable in the setting.
+	
+	_initialize_third_party()
+	
 	if !_enabled:
 		return
 		
@@ -131,7 +139,29 @@ func _export_begin(features : PackedStringArray, is_debug : bool, path : String,
 		for script_path in paths:
 			_parse_script(script_path)
 	
+	# GDShedor
+	if Engine.has_singleton(&"GDShedor"):
+		for _settings in Engine.get_main_loop().get_nodes_in_group(&"GDShedor"):
+			var packed : PackedStringArray = _settings.call(&"get_custom_locked")
+			var data : Dictionary = _settings.call(&"get_custom_names")
+			
+			for smb in packed:
+				smb = smb.strip_edges()
+				if smb.is_empty() or smb.begins_with("#"):
+					continue
+					
+				_symbols.lock_symbol_name(smb)
+				
+			for k : StringName in data.keys():
+				var symb : SymbolTable.Symbol = _symbols.create_global_symbol(k)
+				var key : StringName = data[k]
+				_symbols.lock_symbol_name(key)
+				
+				_symbols.rename_symbol(symb, key)
+				
+				
 	_symbols.resolve_symbol_paths()
+	
 	#if settings.obfuscation_enabled: #settings.obfuscation_enabled # Discrepancy with the objective of this variable in the setting.
 		# JUMP 127
 	_symbols.obfuscate_symbols()
@@ -522,9 +552,20 @@ func _convert_text_to_binary_resource(extension : String, text_data : String) ->
 
 func strip(path : String) -> String:
 	var out : String = ""
-	if _Settings.current.strip_comments:
-		var resources : PackedStringArray = ResourceObfuscator.Resources
-		if FileAccess.file_exists(path) and path.get_extension().begins_with(resources[resources.size() - 1]):
+	
+	var resources : PackedStringArray = ResourceObfuscator.Resources
+	if FileAccess.file_exists(path) and path.get_extension().begins_with(resources[resources.size() - 1]):
+		if Engine.has_singleton(&"GDShedor"):
+			for _settings in Engine.get_main_loop().get_nodes_in_group(&"GDShedor"):
+				if _settings.has_method(&"set_buffer"):
+					var instance : Object = Engine.get_singleton(&"GDShedor")
+					var data : String = FileAccess.get_file_as_string(path)
+					_settings.call(&"set_buffer", data)
+					instance.notification(2162314)
+					out = instance.get_data()
+					break
+	
+		elif _Settings.current.strip_comments:
 			var data : String = FileAccess.get_file_as_string(path)
 			var idx : int = 0
 			for x : RegExMatch in ResourceObfuscator.c_strip.search_all(data):

--- a/addons/gdmaim/plugin.gd
+++ b/addons/gdmaim/plugin.gd
@@ -35,6 +35,11 @@ func _enter_tree() -> void:
 	get_editor_interface().get_base_control().add_child(source_map_viewer)
 
 	_setup()
+	
+	# GDShedor
+	if Engine.has_singleton(&"GDShedor"):
+		for _settings in Engine.get_main_loop().get_nodes_in_group(&"GDShedor"):
+			_settings.call(&"disable_export_check", true)
 
 # Called when exiting scene tree
 func _exit_tree() -> void:
@@ -50,6 +55,11 @@ func _exit_tree() -> void:
 		source_map_viewer.queue_free()
 		
 	_check_settings()
+	
+	# GDShedor
+	if Engine.has_singleton(&"GDShedor"):
+		for _settings in Engine.get_main_loop().get_nodes_in_group(&"GDShedor"):
+			_settings.call(&"disable_export_check", false)
 
 
 # Opens the source map viewer


### PR DESCRIPTION
This pull add compatibility with GDShedor plugin.

## GDShedor Shader Obfuscator


![image](https://github.com/CodeNameTwister/GDShedor/blob/main/assets/0.gif?raw=true)


* Allow use the GDShedor settings.
* Automatic shader processing with GDShedor settings when exporting with GDMaim enabled.

[GDShedor itch.io.com](https://codenametwister.itch.io/gdshedor?secret=Y7vKIKoMlerSMQdNMCcarj9Pno)