### PR TITLE
Obfuscation fixes

### DIFF
--- a/addons/gdmaim/obfuscator/script/parser/parser.gd
+++ b/addons/gdmaim/obfuscator/script/parser/parser.gd
@@ -48,13 +48,6 @@ func _parse_block_with_callback(parent : AST.ASTNode, indentation : int, token_p
 		if _bracket_lock < 0:
 			break
 		
-		if _bracket_lock == 0 and token.is_punctuator(','):
-			token = _tokenizer.peek(1)
-			while token:
-				token_process.call(ast, line, token, indentation)
-				token = _tokenizer.peek(1)
-			break
-		
 		if prev_line and prev_line != line and line.has_statement() and line.get_indentation() <= indentation and _bracket_lock == 0 and not _statement_break:
 			break
 		else:

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -105,8 +105,8 @@ func generate_line_mappings() -> Array[Dictionary]:
 				
 				if not mappings_in.has(current_s):
 					mappings_in[current_s] = current_o
-				if not mappings_out.has(current_o):
-					mappings_out[current_o] = current_s
+				
+				mappings_out[current_o] = current_s
 			
 			# Advance the trackers by the number of newlines INSIDE this specific token
 			out_line += lines_in_token.size() - 1

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -165,7 +165,7 @@ func _string_obfuscation(token : Token) -> void:
 				tail += candy_holders[x]
 				
 			# prevent set_value from removing the first character if it's % instead of a quote "
-			token.set_value("\"" + tail)
+			token.set_value(token.decorator + tail)
 			return
 			
 	token.set_value(_symbol_table.obfuscate_string_global(str))
@@ -241,10 +241,9 @@ func _func_feature_filter(token : Token, line : Tokenizer.Line, feature : String
 		tokenizer.get_output_line(line_idx_from + 1).insert_token(1, Token.new(Token.Type.KEYWORD, func_body, 0, line_idx_from + 1))
 		while line_idx < tokenizer.get_output_line_count():
 			var tline : Tokenizer.Line = tokenizer.get_output_line(line_idx)
-			if tline.has_statement():
-				if tline.get_indentation() <= indentation:
-					break
-				last_valid = line_idx
+			if tline.has_statement() and tline.get_indentation() <= indentation:
+				break
+			last_valid = line_idx
 			if tline.tokens:
 				tokenizer.seek_token(tline.tokens[0])
 			line_idx += 1

--- a/addons/gdmaim/obfuscator/script/script_obfuscator.gd
+++ b/addons/gdmaim/obfuscator/script/script_obfuscator.gd
@@ -78,22 +78,50 @@ func generate_line_mappings() -> Array[Dictionary]:
 	var mappings_in : Dictionary
 	var mappings_out : Dictionary
 	var output_lines : Array[Tokenizer.Line] = tokenizer.get_output_lines()
-	for i in output_lines.size():
-		var line : Tokenizer.Line = output_lines[i]
+	
+	var out_line : int = 0
+	
+	for line in output_lines:
+		var src_line : int = -1
+		
+		# Find the block's starting line from the first valid token.
 		for token in line.tokens:
 			if token.line != -1:
-				mappings_in[token.line] = i
-				mappings_out[i] = token.line
+				src_line = token.line
 				break
-	#HACK it works?
-	mappings_in[tokenizer.line_count-1] = output_lines.size()
-	mappings_out[output_lines.size()] = tokenizer.line_count-1
+		
+		# Skip empty padding lines added by the tokenizer
+		if src_line == -1 and line.tokens.is_empty():
+			continue
+			
+		for token in line.tokens:
+			var text : String = token.get_value()
+			var lines_in_token : PackedStringArray = text.split("\n")
+			
+			# Map every internal line of the token 1:1
+			for nl_idx in lines_in_token.size():
+				var current_s = src_line + nl_idx
+				var current_o = out_line + nl_idx
+				
+				if not mappings_in.has(current_s):
+					mappings_in[current_s] = current_o
+				if not mappings_out.has(current_o):
+					mappings_out[current_o] = current_s
+			
+			# Advance the trackers by the number of newlines INSIDE this specific token
+			out_line += lines_in_token.size() - 1
+			src_line += lines_in_token.size() - 1
+
+	mappings_in[tokenizer.line_count-1] = out_line
+	mappings_out[out_line] = tokenizer.line_count-1
 	
 	var last_valid : int = 0
 	for i in tokenizer.line_count:
-		var from : int = mappings_in.get(i, last_valid)
-		last_valid = from
-		mappings_in[i] = from
+		var from : int = mappings_in.get(i, -1)
+		if from != -1:
+			last_valid = from
+		else:
+			mappings_in[i] = last_valid
 	
 	return [mappings_in, mappings_out]
 

--- a/addons/gdmaim/obfuscator/script/tokenizer/token.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/token.gd
@@ -45,7 +45,10 @@ func _to_string() -> String:
 
 
 func set_value(new_val : String) -> void:
-	_value.set_value(new_val.substr(len(decorator), len(new_val)-len(decorator)) if decorator else new_val)
+	if decorator and new_val.begins_with(decorator):
+		_value.set_value(new_val.substr(len(decorator)))
+	else:
+		_value.set_value(new_val)
 
 
 func get_value(decorated : bool = true) -> String:

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -257,8 +257,6 @@ func _read_multi_string() -> void:
 			mf = true
 			while char == end:
 				char = _stream.get_next()
-				
-		
 			
 		if char == "\\":
 			pass
@@ -275,6 +273,25 @@ func _read_multi_string() -> void:
 		_add_comment(t3 + str + t3)
 	else:
 		_add_string_multi_line(str, t3)
+	
+	# Capture the indentation of the line where the multistring started
+	var initial_indentation : String = ""
+	var current_line : Line = _output.back()
+	if current_line.tokens and current_line.tokens[0].type == Token.Type.INDENTATION:
+		initial_indentation = current_line.tokens[0].get_value()
+		
+	# Append padding lines to maintain 1:1 line counting & indentation depth so the AST doesn't drop scope.
+	var absorbed_newlines : int = str.count("\n")
+	for i in absorbed_newlines:
+		line_count += 1
+		var new_line := Line.new()
+		
+		if initial_indentation:
+			# Create an INDENTATION token mapped strictly to this padding line
+			var indent_token := Token.new(Token.Type.INDENTATION, initial_indentation, _tokens.size(), _output.size(), "")
+			new_line.add_token(indent_token)
+			
+		_output.append(new_line)
 		
 	_can_be_nodepath = false
 

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -230,7 +230,7 @@ func _read_string() -> void:
 func _read_multi_string() -> void:
 	var end : String = _stream.get_next()
 	var t3 : String = str(end,end,end)
-	var str : String = t3
+	var str : String = ""
 	var mf : bool = false
 	var comment : bool = true
 	
@@ -258,19 +258,6 @@ func _read_multi_string() -> void:
 			while char == end:
 				char = _stream.get_next()
 				
-		if char == "\n":
-			if !str.is_empty():
-				if comment:
-					_add_comment(str+"\n")
-				else:
-					_add_string_multi_line(str, "")
-				
-			str = ""
-			
-			_add_line_break()
-			line_count += 1
-			_output.append(Line.new())
-			continue
 		
 			
 		if char == "\\":
@@ -278,19 +265,16 @@ func _read_multi_string() -> void:
 			
 		if char == end:
 			if _stream.peek(1) == end and _stream.peek(2) == end and _stream.peek(3) != end:
-				str += str(_stream.get_next(), _stream.get_next())
+				_stream.get_next()
+				_stream.get_next()
 				break
 			
 		str += char
 		
-	if !str.is_empty():
-		while !str.ends_with(t3):
-			str += end
-			
-		if comment:
-			_add_comment(str)
-		else:
-			_add_string_multi_line(str, "")
+	if comment:
+		_add_comment(t3 + str + t3)
+	else:
+		_add_string_multi_line(str, t3)
 		
 	_can_be_nodepath = false
 

--- a/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
+++ b/addons/gdmaim/obfuscator/script/tokenizer/tokenizer.gd
@@ -274,26 +274,35 @@ func _read_multi_string() -> void:
 	else:
 		_add_string_multi_line(str, t3)
 	
+	# Discard any trailing whitespace
+	if _is_whitespace(_stream.peek()):
+		_read_whitespace()
+	
+	# Determine if the str is followed by a newline or string function.
+	var has_newline : bool = _stream.peek() == "\n"
+	if has_newline:
+		_stream.get_next()
+		_add_line_break()
+	
 	# Capture the indentation of the line where the multistring started
-	var initial_indentation : String = ""
-	var current_line : Line = _output.back()
-	if current_line.tokens and current_line.tokens[0].type == Token.Type.INDENTATION:
-		initial_indentation = current_line.tokens[0].get_value()
+	var base_indent := ""
+	if _output.back().tokens and _output.back().tokens[0].type == Token.Type.INDENTATION:
+		base_indent = _output.back().tokens[0].get_value()
 		
 	# Append padding lines to maintain 1:1 line counting & indentation depth so the AST doesn't drop scope.
-	var absorbed_newlines : int = str.count("\n")
-	for i in absorbed_newlines:
+	for i in str.count("\n"):
 		line_count += 1
 		var new_line := Line.new()
-		
-		if initial_indentation:
-			# Create an INDENTATION token mapped strictly to this padding line
-			var indent_token := Token.new(Token.Type.INDENTATION, initial_indentation, _tokens.size(), _output.size(), "")
-			new_line.add_token(indent_token)
-			
+		if base_indent:
+			new_line.add_token(Token.new(Token.Type.INDENTATION, base_indent, _tokens.size(), _output.size(), ""))
 		_output.append(new_line)
-		
-	_can_be_nodepath = false
+	
+	# Ensure we force a newline after a bare multiline string
+	if has_newline:
+		line_count += 1
+		_output.append(Line.new())
+	
+	_can_be_nodepath = has_newline
 
 func _read_node_path() -> void:
 	var str : String


### PR DESCRIPTION
Related to #128 and continuation of #121 

1. Adds a working multiline string implementation to the tokenizer supporting both ''' and """ decorators as well as trailing string functions using . notation.
2. Adds multiline token support to the script_obfuscator.gd line mapping function for the source code viewer.
3. Fixes AST Parser bug that absorbs an entire file after comma separated match statements.

GIF below shows linemappings (first scrolls through source code top to bottom, then scrolls through output top to bottom).
<img width="1368" height="988" alt="Recording 2026-05-28 153828" src="https://github.com/user-attachments/assets/770f80f0-549d-48a9-ba3c-06734753111c" />
