### PR TITLE
Fix parser symbol bugs and space-to-tab indentation corruption

### DIFF
--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -613,7 +613,37 @@ static func _generate_uuid(path : String) -> String:
 	return "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x" % (bytes as Array)
 
 func _space2tabs(src: String) -> String:
+	# Converts leading indentation spaces to tabs, line by line.
+	# Only the leading whitespace of each line is modified; spaces inside string
+	# literals and elsewhere in the line are left untouched.
+	# Note: leading spaces in multiline string literals (""") are still affected —
+	# this is a known accepted limitation.
 	if _space_rgx == null:
-		_space_rgx = RegEx.create_from_string(" {%d}" % _space_tabs_size)
-	src = _space_rgx.sub(src, "\t", true)
-	return src
+		_space_rgx = RegEx.create_from_string("^([ \t]*)")
+	var n : int = _space_tabs_size
+	var lines : PackedStringArray = src.split("\n", true)
+	for i in lines.size():
+		var line : String = lines[i]
+		var m : RegExMatch = _space_rgx.search(line)
+		if m == null:
+			continue
+		var leading : String = m.get_string(1)
+		if leading.is_empty():
+			continue
+		# Count existing tabs and spaces in the leading whitespace, then convert
+		# every N consecutive spaces to one tab (existing tabs are kept as-is).
+		var tabs : int = 0
+		var spaces : int = 0
+		for ch in leading:
+			if ch == "\t":
+				# A tab that was already there counts as one indent level.
+				tabs += 1
+				spaces = 0 # reset any partial space run before this tab
+			else:
+				spaces += 1
+				if spaces == n:
+					tabs += 1
+					spaces = 0
+		var new_leading : String = "\t".repeat(tabs) + " ".repeat(spaces)
+		lines[i] = new_leading + line.substr(leading.length())
+	return "\n".join(lines)

--- a/addons/gdmaim/obfuscator/script/parser/parser.gd
+++ b/addons/gdmaim/obfuscator/script/parser/parser.gd
@@ -526,8 +526,15 @@ func _parse_enum(parent : AST.ASTNode) -> AST.EnumDef:
 	
 	if _class_symbol and ast:
 		_class_symbol.add_child(ast.symbol)
-	
+
 	return ast
+
+
+# Mirrors SymbolTable.create_symbol(): true for declarations which received a
+# global symbol. Function-local declarations get uniquely renamed symbols, so
+# registering them as class members would shadow same-named global members.
+func _is_class_level(ast : AST.ASTNode) -> bool:
+	return ast.get_parent() is AST.Sequence and ast.get_parent().get_parent() is AST.Class
 
 
 func _parse_enum_key(parent : AST.ASTNode) -> AST.EnumDef.KeyDef:
@@ -574,9 +581,9 @@ func _parse_const(parent : AST.ASTNode) -> AST.Const:
 	if _line_has_hint(PreprocessorHints.LOCK_SYMBOLS):
 		_symbol_table.lock_symbol(ast.symbol)
 	
-	if _class_symbol:
+	if _class_symbol and _is_class_level(ast):
 		_class_symbol.add_child(ast.symbol)
-	
+
 	return ast
 
 
@@ -598,9 +605,9 @@ func _parse_var(parent : AST.ASTNode) -> AST.Var:
 	ast.default = _parse_var_default(ast)
 	ast.getset = _parse_var_getset(ast)
 	
-	if _class_symbol and (_is_autoload or is_static):
+	if _class_symbol and (_is_autoload or is_static) and _is_class_level(ast):
 		_class_symbol.add_child(ast.symbol)
-	
+
 	return ast
 
 
@@ -719,9 +726,9 @@ func _parse_func(parent : AST.ASTNode) -> AST.Func:
 			if string_params.has(params[i].symbol.get_name()):
 				ast.symbol.add_string_param(i)
 	
-	if _class_symbol and (_is_autoload or is_static):
+	if _class_symbol and (_is_autoload or is_static) and _is_class_level(ast):
 		_class_symbol.add_child(ast.symbol)
-	
+
 	_bracket_lock += bracket_lock
 	if bracket_lock:
 		_current_indentation = indentation
@@ -820,6 +827,7 @@ func _parse_var_default(parent : AST.ASTNode) -> AST.Sequence:
 						if function:
 							ast.statements.append(function)
 				Token.Type.SYMBOL:
+					_statement_break = false  # Statement break persists until next non-whitespace token
 					var symbol : AST.ASTNode = _parse_symbol(ast)
 					if symbol:
 						ast.statements.append(symbol)
@@ -827,9 +835,11 @@ func _parse_var_default(parent : AST.ASTNode) -> AST.Sequence:
 					if token.get_value() == ':' and _bracket_lock <= 0:
 						return false
 					else:
+						_statement_break = false
 						_parse_punctuator()
 				_:
 					if not _parse_and_process_indentation():
+						_statement_break = false
 						_tokenizer.get_next()
 			return true
 		)
@@ -860,6 +870,7 @@ func _parse_var_getset(parent : AST.ASTNode) -> AST.Sequence:
 					_tokenizer.get_next()
 			else:
 				if not _parse_and_process_indentation():
+					_statement_break = false  # Statement break persists until next non-whitespace token
 					_tokenizer.get_next()
 			return true
 		)


### PR DESCRIPTION
Three fixes for bugs that produced broken or corrupted obfuscated output (see commit message for per-fix details):

- parser.gd: reset _statement_break in the SYMBOL/PUNCTUATOR/default branches of _parse_var_default's callback, so a backslash line continuation in a var initializer no longer swallows the next line into the initializer (leaving its identifiers unlinked and producing stale names beside renamed ones in the exported output).
- parser.gd: only register class-level declarations as members of the autoload/class symbol. A function-local sharing a member name no longer clobbers the member's entry, which previously made external Autoload.member() call sites resolve to the local's generated name while the definition kept the shared global name.
- export_plugin.gd: rewrite _space2tabs to convert only leading indentation line by line, instead of replacing N-space runs anywhere in the line (which corrupted spaces inside string literals).