### PR TITLE
Fix null _Settings.current during headless/CLI export

### DIFF
--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -59,6 +59,10 @@ func _initialize_third_party() -> void:
 			_settings.call(&"disable_export_check", true)
 
 func _export_begin(features : PackedStringArray, is_debug : bool, path : String, flags : int) -> void:
+	# Headless/CLI exports don't run the editor plugin's _enter_tree(), so `settings` may be unset
+	# here. Fall back to the (lazily-initialized) shared singleton the obfuscator components read.
+	if not settings:
+		settings = _Settings.current
 	_features = features
 	_export_path = path
 	_source_map_filename = _export_path.get_file().get_basename() + Time.get_datetime_string_from_system().replace(":", ".") + ".gd.map"

--- a/addons/gdmaim/settings.gd
+++ b/addons/gdmaim/settings.gd
@@ -69,7 +69,18 @@ var _cfg := ConfigFile.new()
 var _entries : Dictionary
 var _categories : Array[Category]
 
-static var current : _Settings
+static var _current : _Settings
+
+# Lazily initialized so headless/CLI exports — and any context that never ran the editor
+# plugin's _enter_tree() — still get a valid, export.cfg-loaded Settings instead of null.
+# Constructing a _Settings runs _init(), which sets `current = self` and loads export.cfg.
+static var current : _Settings:
+	get:
+		if not _current:
+			_current = _Settings.new()
+		return _current
+	set(value):
+		_current = value
 
 func _init() -> void:
 	current = self


### PR DESCRIPTION
## Problem

<img width="1049" height="611" alt="image" src="https://github.com/user-attachments/assets/20762808-b5b7-4502-bc28-e8333d9455ff" />


`Tokenizer`, `ScriptObfuscator`, `SourceMapViewer`, and `export_plugin` read configuration from the global `static var _Settings.current`. That static is only ever populated as a *side effect* of constructing a `_Settings`, and the sole production caller is the editor plugin's `_enter_tree()`.

During a headless / CLI export (`godot --headless --export-release`, i.e. CI or a build script), that editor bootstrap doesn't wire things up, so:

- `_Settings.current` is `null` → every component that reads it hits a null dereference during obfuscation.
- `export_plugin.settings` (injected only by `_enter_tree()`) is also `null` → `_export_begin` fails at `settings.obfuscation_enabled`.

The result is that obfuscation can't run from a command-line/CI export without manually patching several files to lazily construct settings.

## Fix

Make `_Settings.current` a **lazily-initialized singleton** — the getter constructs a `_Settings` (which loads `export.cfg` in `_init()`) if none exists yet. This centralizes what would otherwise be scattered per-call-site null guards into the property itself, and works in any context: editor, headless export, CI, or standalone tooling.

`_export_begin` also falls back to `_Settings.current` for its own `settings` member when the editor bootstrap didn't inject one.

Editor behavior is unchanged: `plugin.gd._enter_tree()` still eagerly calls `_Settings.new()`, so `current` is set up front and the dock edits that instance.

## Testing

Headless, no-editor context (`SceneTree` via `--script`), cold-reading `_Settings.current` with no prior `_Settings.new()` and no editor plugin:

| | `_Settings.current` |
|---|---|
| before | `<null>` |
| after | non-null, `export.cfg`-loaded, stable singleton across accesses |

All affected scripts compile: `settings.gd`, `export_plugin.gd`, `tokenizer.gd`, `script_obfuscator.gd`, `source_map_viewer.gd`, `plugin.gd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)