### PR TITLE
Correct export_presets.cfg Section Targets for GDMaim Source Exclusion

### DIFF
--- a/addons/gdmaim/plugin.gd
+++ b/addons/gdmaim/plugin.gd
@@ -130,10 +130,13 @@ func _export_init() -> bool:
 	
 	if err == OK:
 		for sector : String in config.get_sections():
+			if not sector.begins_with("preset.") or sector.ends_with(".options"):
+				if config.has_section_key(sector, excl):
+					config.erase_section_key(sector, excl)
+					dirty = true
+				continue
 			var filters : String = config.get_value(sector, excl, "")
 			if plug in filters:
-				if !sector.ends_with(".options") and !config.has_section(sector + ".options"):
-					config.set_value(sector + ".options", excl, plug)
 				continue
 			if !filters.is_empty():
 				filters += ","


### PR DESCRIPTION
The "exclude_filters" key should ONLY be set in the main section for each preset (see https://github.com/godotengine/godot/blob/master/editor/export/editor_export.cpp). 

It is invalid in the .options section or other sections. The existing code forcefully added this key to every section which is incorrect and causes invalid key bloat. 

This is fixed by specifically targeting the main preset sections where Godot actually looks for the exclude_filter key.