### PR TITLE
Add missing @tool annotation to settings.gd

### DIFF
--- a/addons/gdmaim/settings.gd
+++ b/addons/gdmaim/settings.gd
@@ -1,3 +1,4 @@
+@tool
 extends RefCounted
 
 


### PR DESCRIPTION
## Problem

`settings.gd` declares `static var current : _Settings`, which is accessed from
`@tool` scripts such as `ui/source_map_viewer/source_map_viewer.gd`. However,
`settings.gd` itself is missing the `@tool` annotation.

Godot determines whether to run static initialization in `GDScript::reload()`:

```cpp
bool can_run = ScriptServer::is_scripting_enabled() || is_tool();
```

When `can_run` is false, the engine skips `_static_init()`,
`_save_old_static_data()` and `_restore_old_static_data()`. Since scripting is
disabled in the editor, a non-`@tool` script never gets its static variables
initialized or preserved across reloads, so `_Settings.current` stays `null`
inside the editor.

## Symptom

Enabling the plugin (or reloading scripts while it is enabled) produces:

```
res://addons/gdmaim/ui/source_map_viewer/source_map_viewer.gd:204 -
Invalid access to property or key 'preprocessor_prefix' on a base object of type 'Nil'.
```

`_Settings.current` is `Nil` at that point.

## Fix

Add `@tool` to the top of `addons/gdmaim/settings.gd`.

As a general rule, a script holding static variables that are read from `@tool`
scripts must be marked `@tool` as well.

## Testing

- Enabled the plugin in the Godot editor and confirmed the error no longer occurs.
- Opened the Source Map Viewer and confirmed settings are read correctly.