### PR TITLE
Fix _parse_params misreading commas inside generic type annotations

### DIFF
--- a/addons/gdmaim/obfuscator/script/parser/parser.gd
+++ b/addons/gdmaim/obfuscator/script/parser/parser.gd
@@ -754,6 +754,7 @@ func _parse_params(parent : AST.ASTNode) -> Array[AST.Parameter]:
 		return params
 	
 	var pth : int = 0
+	var brackets : int = 0
 	var param := AST.Parameter.new(parent)
 	var expect_symbol : bool = true
 	while !_tokenizer.is_eof():
@@ -769,7 +770,11 @@ func _parse_params(parent : AST.ASTNode) -> Array[AST.Parameter]:
 						params.append(param)
 					param = AST.Parameter.new(parent)
 					return params
-			elif token.has_value(",") and pth == 1:
+			elif token.has_value("["):
+				brackets += 1
+			elif token.has_value("]"):
+				brackets -= 1
+			elif token.has_value(",") and pth == 1 and brackets == 0:
 				expect_symbol = true
 				params.append(param)
 				param = AST.Parameter.new(parent)


### PR DESCRIPTION
## Problem

`_parse_params()` tracks parenthesis depth (`pth`) but not bracket depth, so a
comma inside a typed collection annotation is mistaken for a parameter
separator.

For a declaration such as:

```gdscript
func collect(used: Dictionary[int, bool] = {}) -> void:
```

the parser splits at the comma inside `Dictionary[int, bool]`, treats `bool` as
the start of a new parameter, and registers it as a local symbol. The obfuscator
then renames `bool` to a generated identifier:

```gdscript
func __xxxx(__yyyy: Dictionary[int, __zzzz] = {}) -> void:
```

`__zzzz` is undefined, so the whole script fails to compile in the exported
build. The same applies to `Array[...]` and any other bracketed type argument
list.

## Symptom

The affected script silently fails to load at runtime. In our project this hit
an autoload, which made every call into it fail and left the game stuck on a
loading error loop. Because the failure happens at script load time, it does not
reproduce in the editor and only appears in obfuscated exports.

## Fix

Track bracket depth alongside parenthesis depth and only treat `,` as a
parameter separator when `pth == 1 and brackets == 0`.

## Testing

- Confirmed `func f(used: Dictionary[int, bool] = {})` is no longer mis-split and
  `bool` is left untouched in the obfuscated output.
- Confirmed ordinary parameter lists and default values are unaffected.