### PR TITLE
New option setting: Allow use regex on custom tokens file.

### DIFF
--- a/addons/gdmaim/export_plugin.gd
+++ b/addons/gdmaim/export_plugin.gd
@@ -125,15 +125,30 @@ func _export_begin(features : PackedStringArray, is_debug : bool, path : String,
 		for func_ in variant.get("methods", []):
 			_symbols.lock_symbol_name(func_)
 			
+	settings.custom_token_regex_buffer.clear()
 	if settings.use_custom_token_ignore_file:
 		var file : String = settings.custom_token_ignore_file_path
 		if FileAccess.file_exists(file):
-			var packed : PackedStringArray = FileAccess.get_file_as_string(file).split("\n")
-			for smb in packed:
-				smb = smb.strip_edges()
-				if smb.is_empty() or smb.begins_with("#"):
-					continue
-				_symbols.lock_symbol_name(smb)
+			var packed : PackedStringArray = FileAccess.get_file_as_string(file).split("\n") 
+			
+			if settings.use_custom_token_as_regex:				
+				for smb in packed:
+					smb = smb.strip_edges()
+					if smb.is_empty() or smb.begins_with("#"):
+						continue
+						
+					var rgx : RegEx = RegEx.create_from_string(smb, false)
+					
+					if rgx.is_valid():
+						settings.custom_token_regex_buffer.append(rgx)
+					else:
+						printerr("An invalid regex sentence of {0} in custom token file".format([smb]))
+			else:			
+				for smb in packed:
+					smb = smb.strip_edges()
+					if smb.is_empty() or smb.begins_with("#"):
+						continue
+					_symbols.lock_symbol_name(smb)
 	
 	# Gather built-in class symbols
 	for class_ in ClassDB.get_class_list():
@@ -283,6 +298,9 @@ func _export_end() -> void:
 	_src_obfuscators.clear()
 	_res_obfuscators.clear()
 	_Logger.clear_all()
+	
+	if is_instance_valid(settings):
+		settings.custom_token_regex_buffer.clear()
 
 
 func _export_file(path : String, type : String, features : PackedStringArray) -> void:

--- a/addons/gdmaim/obfuscator/symbol_table.gd
+++ b/addons/gdmaim/obfuscator/symbol_table.gd
@@ -127,17 +127,37 @@ func resolve_symbol_paths() -> void:
 
 
 func obfuscate_symbols() -> void:
-	for symbol in _local_symbols:
-		if !_locked_symbols.has(symbol.get_name()):
-			rename_symbol(symbol, _generate_symbol_name(symbol.get_name(), true))
-	
-	for symbol in _global_symbols.values():
-		if !_locked_symbols.has(symbol.get_name()):
-			rename_symbol(symbol, _generate_symbol_name(symbol.get_name()))
+	if _Settings.current.custom_token_regex_buffer:
+		for symbol in _local_symbols:
+			var str : String = symbol.get_name()
+			if !_locked_symbols.has(str) and !is_custom_lock_settings(str):
+				rename_symbol(symbol, _generate_symbol_name(str, true))
+		
+		for symbol in _global_symbols.values():
+			var str : String = symbol.get_name()
+			if !_locked_symbols.has(str) and !is_custom_lock_settings(str):
+				rename_symbol(symbol, _generate_symbol_name(str))
+		
+	else:
+		for symbol in _local_symbols:
+			var str : String = symbol.get_name()
+			if !_locked_symbols.has(symbol.get_name()):
+				rename_symbol(symbol, _generate_symbol_name(str, true))
+		
+		for symbol in _global_symbols.values():
+			var str : String = symbol.get_name()
+			if !_locked_symbols.has(str):
+				rename_symbol(symbol, _generate_symbol_name(str))
 
+func is_custom_lock_settings(str : String) -> bool:
+	for rgx in _Settings.current.get_tokens_rgx():
+		if null != rgx.search(str):
+			_locked_symbols[str] = true
+			return true
+	return false
 
 func obfuscate_string_global(str : String) -> String:
-	return _generate_symbol_name(str) if !_locked_symbols.has(str) else str
+	return _generate_symbol_name(str) if !_locked_symbols.has(str) and !is_custom_lock_settings(str) else str
 
 
 func _search_symbol(ast_node : AST.ASTNode, name : String, is_func : bool) -> Symbol:

--- a/addons/gdmaim/settings.gd
+++ b/addons/gdmaim/settings.gd
@@ -42,6 +42,9 @@ var export_mode : int = GDScriptExportMode.TEXT
 
 var use_custom_token_ignore_file : bool = false
 var custom_token_ignore_file_path : String = "res://addons/gdmaim/user/ignore_tokens.txt"
+var use_custom_token_as_regex : bool = false
+var custom_token_regex_buffer : Array = []
+
 var exclude_files : PackedStringArray = []
 var _exclude_files : String = "":
 	set(value):
@@ -124,7 +127,8 @@ func initialize_settings(make_as_global_settings : bool = false, force_load_conf
 	set_category("exclude_files_category", "Exclusion")
 	add_entry("_exclude_files", "multi_filepath", "Path", "Select files or folders to be excluded from obfuscation; excluded scripts will maintain compatibility with the other obfuscated scripts.").set_custom_type(Entry.CustomType.MULTI_FILE_PATH, "")
 	add_entry("exclude_resources", "resources", "Exclude Resources", "If true, resources like PackedScenes will be ignored during scanning.\nThis is useful if you typically have a lot of embedded resources in your resources and causing problems such as freezing.\n\n(WARNING) This could cause errors if you reference scripts within your packaged scenes, such as signals or exported variables. (Source of embedded scripts are the exception)\n\nRemember that this can be solved by following the best practices recommended in the official repository.")
-	add_entry("use_custom_token_ignore_file", "custom_tokens_enabled", "Custom Token File", "If true, any token defined by you in\n'{0}'\nwill be ignored".format([custom_token_ignore_file_path]))
+	add_entry("use_custom_token_ignore_file", "custom_tokens_enabled", "Custom Tokens File", "If true, any token defined by you in\n'{0}'\nwill be ignored".format([custom_token_ignore_file_path]))
+	add_entry("use_custom_token_as_regex", "custom_tokens_as_regex_enabled", "Custom Tokens as regex", "If true, any token defined by you in\n'{0}'\nwill be read as regex setence.\n\nRequire 'Custom Tokens File' Enabled".format([custom_token_ignore_file_path]))
 	
 	#set_category("debug", "Debug")
 	#add_entry("debug_scripts", debug_scripts", "", "")
@@ -189,6 +193,10 @@ func _read_entries() -> void:
 
 func _get_cfg_dir() -> String:
 	return get_script().resource_path.get_base_dir()
+	
+	
+func get_tokens_rgx() -> Array:
+	return custom_token_regex_buffer
 
 
 class Category:


### PR DESCRIPTION
Added new option "Custom Tokens as regex" *(require "Custom Tokens File" enabled)*

Regex statements can now be used for the custom token file, this facilitates the customization of variables that are intended to be maintained without becoming obfuscated.

Example:

Before
```
#in res://addons/gdmaim/user/ignore_tokens.txt

mod_variable_1
mod_variable_2
mod_variable_3
```

After
```
#in res://addons/gdmaim/user/ignore_tokens.txt

mod_*
```

Following the previous example, all tokens that begin with "mod_" will not be obfuscated.


_If you follow this same example, In your case you could replace "mod\_" with something you use leaving it as an example str\_\* var\_\* serialized\_\* . etc_